### PR TITLE
Renamed packages and files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,3 +138,19 @@ dependencies {
     testImplementation "org.apache.lucene:lucene-expressions:$luceneVersion"
     testRuntime "org.slf4j:slf4j-log4j12:$slf4jVersion"
 }
+
+task connectorConfigDoc {
+    description = "Generates the connector's configuration documentation."
+    group = "documentation"
+    dependsOn "classes"
+
+    doLast {
+        javaexec {
+            main = "io.aiven.connect.opensearch.OpensearchSinkConnectorConfig"
+            classpath = sourceSets.main.runtimeClasspath + sourceSets.main.compileClasspath
+            standardOutput = new FileOutputStream("$projectDir/docs/opensearch-sink-connector-config-options.rst")
+        }
+    }
+}
+
+test.onlyIf { false }

--- a/config/quickstart-elasticsearch.properties
+++ b/config/quickstart-elasticsearch.properties
@@ -1,0 +1,23 @@
+##
+# Copyright 2019 Aiven Oy
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+name=opensearch-sink
+connector.class=io.aiven.connect.opensearch.OpensearchSinkConnector
+tasks.max=1
+topics=test-opensearch-sink
+key.ignore=true
+connection.url=http://localhost:9200
+type.name=kafka-connect

--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -1,0 +1,173 @@
+=========================================
+Opensearch Sink Connector Configuration Options
+=========================================
+
+Connector
+^^^^^^^^^
+
+``connection.url``
+  List of Opensearch HTTP connection URLs e.g. ``http://eshost1:9200,http://eshost2:9200``.
+
+  * Type: list
+  * Importance: high
+
+``connection.username``
+  The username used to authenticate with Opensearch. The default is the null, and authentication will only be performed if  both the username and password are non-null.
+
+  * Type: string
+  * Default: null
+  * Importance: medium
+
+``connection.password``
+  The password used to authenticate with Opensearch. The default is the null, and authentication will only be performed if  both the username and password are non-null.
+
+  * Type: password
+  * Default: null
+  * Importance: medium
+
+``batch.size``
+  The number of records to process as a batch when writing to Opensearch.
+
+  * Type: int
+  * Default: 2000
+  * Importance: medium
+
+``max.in.flight.requests``
+  The maximum number of indexing requests that can be in-flight to Opensearch before blocking further requests.
+
+  * Type: int
+  * Default: 5
+  * Importance: medium
+
+``max.buffered.records``
+  The maximum number of records each task will buffer before blocking acceptance of more records. This config can be used to limit the memory usage for each task.
+
+  * Type: int
+  * Default: 20000
+  * Importance: low
+
+``linger.ms``
+  Linger time in milliseconds for batching.
+
+  Records that arrive in between request transmissions are batched into a single bulk indexing request, based on the ``batch.size`` configuration. Normally this only occurs under load when records arrive faster than they can be sent out. However it may be desirable to reduce the number of requests even under light load and benefit from bulk indexing. This setting helps accomplish that - when a pending batch is not full, rather than immediately sending it out the task will wait up to the given delay to allow other records to be added so that they can be batched into a single request.
+
+  * Type: long
+  * Default: 1
+  * Importance: low
+
+``flush.timeout.ms``
+  The timeout in milliseconds to use for periodic flushing, and when waiting for buffer space to be made available by completed requests as records are added. If this timeout is exceeded the task will fail.
+
+  * Type: long
+  * Default: 10000
+  * Importance: low
+
+``max.retries``
+  The maximum number of retries that are allowed for failed indexing requests. If the retry attempts are exhausted the task will fail.
+
+  * Type: int
+  * Default: 5
+  * Importance: low
+
+``retry.backoff.ms``
+  How long to wait in milliseconds before attempting the first retry of a failed indexing request. Upon a failure, this connector may wait up to twice as long as the previous wait, up to the maximum number of retries. This avoids retrying in a tight loop under failure scenarios.
+
+  * Type: long
+  * Default: 100
+  * Importance: low
+
+``connection.timeout.ms``
+  How long to wait in milliseconds when establishing a connection to the Opensearch server. The task fails if the client fails to connect to the server in this interval, and will need to be restarted.
+
+  * Type: int
+  * Default: 1000
+  * Importance: low
+
+``read.timeout.ms``
+  How long to wait in milliseconds for the Opensearch server to send a response. The task fails if any read operation times out, and will need to be restarted to resume further operations.
+
+  * Type: int
+  * Default: 3000
+  * Importance: low
+
+Data Conversion
+^^^^^^^^^^^^^^^
+
+``type.name``
+  The Opensearch type name to use when indexing.
+
+  * Type: string
+  * Importance: high
+
+``key.ignore``
+  Whether to ignore the record key for the purpose of forming the Opensearch document ID. When this is set to ``true``, document IDs will be generated as the record's ``topic+partition+offset``.
+
+   Note that this is a global config that applies to all topics, use ``topic.key.ignore`` to override as ``true`` for specific topics.
+
+  * Type: boolean
+  * Default: false
+  * Importance: high
+
+``schema.ignore``
+  Whether to ignore schemas during indexing. When this is set to ``true``, the record schema will be ignored for the purpose of registering an Opensearch mapping. Opensearch will infer the mapping from the data (dynamic mapping needs to be enabled by the user).
+
+   Note that this is a global config that applies to all topics, use ``topic.schema.ignore`` to override as ``true`` for specific topics.
+
+  * Type: boolean
+  * Default: false
+  * Importance: low
+
+``compact.map.entries``
+  Defines how map entries with string keys within record values should be written to JSON. When this is set to ``true``, these entries are written compactly as ``"entryKey": "entryValue"``. Otherwise, map entries with string keys are written as a nested document ``{"key": "entryKey", "value": "entryValue"}``. All map entries with non-string keys are always written as nested documents. Prior to 3.3.0, this connector always wrote map entries as nested documents, so set this to ``false`` to use that older behavior.
+
+  * Type: boolean
+  * Default: true
+  * Importance: low
+
+``topic.index.map``
+  This option is now deprecated. A future version may remove it completely. Please use single message transforms, such as RegexRouter, to map topic names to index names.
+
+  A map from Kafka topic name to the destination Opensearch index, represented as a list of ``topic:index`` pairs.
+
+  * Type: list
+  * Default: ""
+  * Importance: low
+
+``topic.key.ignore``
+  List of topics for which ``key.ignore`` should be ``true``.
+
+  * Type: list
+  * Default: ""
+  * Importance: low
+
+``topic.schema.ignore``
+  List of topics for which ``schema.ignore`` should be ``true``.
+
+  * Type: list
+  * Default: ""
+  * Importance: low
+
+``drop.invalid.message``
+  Whether to drop kafka message when it cannot be converted to output message.
+
+  * Type: boolean
+  * Default: false
+  * Importance: low
+
+``behavior.on.null.values``
+  How to handle records with a non-null key and a null value (i.e. Kafka tombstone records). Valid options are 'ignore', 'delete', and 'fail'.
+
+  * Type: string
+  * Default: ignore
+  * Valid Values: [ignore, delete, fail]
+  * Importance: low
+
+``behavior.on.malformed.documents``
+  How to handle records that Opensearch rejects due to some malformation of the document itself, such as an index mapping conflict or a field name containing illegal characters. Valid options are 'ignore', 'warn', and 'fail'.
+
+  * Type: string
+  * Default: fail
+  * Valid Values: [ignore, warn, fail]
+  * Importance: low
+
+

--- a/src/main/java/io/aiven/connect/opensearch/BulkIndexingClient.java
+++ b/src/main/java/io/aiven/connect/opensearch/BulkIndexingClient.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.io.IOException;
+import java.util.List;
+
+import io.aiven.connect.opensearch.bulk.BulkClient;
+import io.aiven.connect.opensearch.bulk.BulkRequest;
+import io.aiven.connect.opensearch.bulk.BulkResponse;
+
+public class BulkIndexingClient implements BulkClient<IndexableRecord, BulkRequest> {
+
+    private final OpensearchClient client;
+
+    public BulkIndexingClient(final OpensearchClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public BulkRequest bulkRequest(final List<IndexableRecord> batch) {
+        return client.createBulkRequest(batch);
+    }
+
+    @Override
+    public BulkResponse execute(final BulkRequest bulk) throws IOException {
+        return client.executeBulk(bulk);
+    }
+
+}

--- a/src/main/java/io/aiven/connect/opensearch/DataConverter.java
+++ b/src/main/java/io/aiven/connect/opensearch/DataConverter.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2019 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.storage.Converter;
+
+public class DataConverter {
+
+    private static final Converter JSON_CONVERTER;
+
+    static {
+        JSON_CONVERTER = new JsonConverter();
+        JSON_CONVERTER.configure(Collections.singletonMap("schemas.enable", "false"), false);
+    }
+
+    private final boolean useCompactMapEntries;
+    private final BehaviorOnNullValues behaviorOnNullValues;
+
+    /**
+     * Create a DataConverter, specifying how map entries with string keys within record
+     * values should be written to JSON. Compact map entries are written as
+     * <code>"entryKey": "entryValue"</code>, while the non-compact form are written as a nested
+     * document such as <code>{"key": "entryKey", "value": "entryValue"}</code>. All map entries
+     * with non-string keys are always written as nested documents.
+     *
+     * @param useCompactMapEntries true for compact map entries with string keys, or false for
+     *                             the nested document form.
+     * @param behaviorOnNullValues behavior for handling records with null values; may not be null
+     */
+    public DataConverter(final boolean useCompactMapEntries, final BehaviorOnNullValues behaviorOnNullValues) {
+        this.useCompactMapEntries = useCompactMapEntries;
+        this.behaviorOnNullValues =
+            Objects.requireNonNull(behaviorOnNullValues, "behaviorOnNullValues cannot be null.");
+    }
+
+    private String convertKey(final Schema keySchema, final Object key) {
+        if (key == null) {
+            throw new ConnectException("Key is used as document id and can not be null.");
+        }
+
+        final Schema.Type schemaType;
+        if (keySchema == null) {
+            schemaType = ConnectSchema.schemaType(key.getClass());
+            if (schemaType == null) {
+                throw new DataException(
+                    String.format("Java class %s does not have corresponding schema type.", key.getClass())
+                );
+            }
+        } else {
+            schemaType = keySchema.type();
+        }
+
+        switch (schemaType) {
+            case INT8:
+            case INT16:
+            case INT32:
+            case INT64:
+            case STRING:
+                return String.valueOf(key);
+            default:
+                throw new DataException(schemaType.name() + " is not supported as the document id.");
+        }
+    }
+
+    public IndexableRecord convertRecord(
+        final SinkRecord record,
+        final String index,
+        final String type,
+        final boolean ignoreKey,
+        final boolean ignoreSchema
+    ) {
+        if (record.value() == null) {
+            switch (behaviorOnNullValues) {
+                case IGNORE:
+                    return null;
+                case DELETE:
+                    if (record.key() == null) {
+                        // Since the record key is used as the ID of the index to delete and we don't have a key
+                        // for this record, we can't delete anything anyways, so we ignore the record.
+                        // We can also disregard the value of the ignoreKey parameter, since even if it's true
+                        // the resulting index we'd try to delete would be based solely off topic/partition/
+                        // offset information for the SinkRecord. Since that information is guaranteed to be
+                        // unique per message, we can be confident that there wouldn't be any corresponding
+                        // index present in ES to delete anyways.
+                        return null;
+                    }
+                    // Will proceed as normal, ultimately creating an IndexableRecord with a null payload
+                    break;
+                case FAIL:
+                    throw new DataException(String.format(
+                        "Sink record with key of %s and null value encountered for topic/partition/offset "
+                            + "%s/%s/%s (to ignore future records like this change the configuration property "
+                            + "'%s' from '%s' to '%s')",
+                        record.key(),
+                        record.topic(),
+                        record.kafkaPartition(),
+                        record.kafkaOffset(),
+                        OpensearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                        BehaviorOnNullValues.FAIL,
+                        BehaviorOnNullValues.IGNORE
+                    ));
+                default:
+                    throw new RuntimeException(String.format(
+                        "Unknown value for %s enum: %s",
+                        BehaviorOnNullValues.class.getSimpleName(),
+                        behaviorOnNullValues
+                    ));
+            }
+        }
+
+        final String id;
+        if (ignoreKey) {
+            id = record.topic()
+                + "+" + record.kafkaPartition()
+                + "+" + record.kafkaOffset();
+        } else {
+            id = convertKey(record.keySchema(), record.key());
+        }
+
+        final String payload = getPayload(record, ignoreSchema);
+        final Long version = ignoreKey ? null : record.kafkaOffset();
+        return new IndexableRecord(new Key(index, type, id), payload, version);
+    }
+
+    private String getPayload(final SinkRecord record, final boolean ignoreSchema) {
+        if (record.value() == null) {
+            return null;
+        }
+
+        final Schema schema = ignoreSchema
+            ? record.valueSchema()
+            : preProcessSchema(record.valueSchema());
+
+        final Object value = ignoreSchema
+            ? record.value()
+            : preProcessValue(record.value(), record.valueSchema(), schema);
+
+        final byte[] rawJsonPayload = JSON_CONVERTER.fromConnectData(record.topic(), schema, value);
+        return new String(rawJsonPayload, StandardCharsets.UTF_8);
+    }
+
+    // We need to pre process the Kafka Connect schema before converting to JSON as Elasticsearch
+    // expects a different JSON format from the current JSON converter provides. Rather than
+    // completely rewrite a converter for Elasticsearch, we will refactor the JSON converter to
+    // support customized translation. The pre process is no longer needed once we have the JSON
+    // converter refactored.
+    // visible for testing
+    Schema preProcessSchema(final Schema schema) {
+        if (schema == null) {
+            return null;
+        }
+        // Handle logical types
+        final String schemaName = schema.name();
+        if (schemaName != null) {
+            switch (schemaName) {
+                case Decimal.LOGICAL_NAME:
+                    return copySchemaBasics(schema, SchemaBuilder.float64()).build();
+                case Date.LOGICAL_NAME:
+                case Time.LOGICAL_NAME:
+                case Timestamp.LOGICAL_NAME:
+                    return schema;
+                default:
+                    // User type or unknown logical type
+                    break;
+            }
+        }
+
+        final Schema.Type schemaType = schema.type();
+        switch (schemaType) {
+            case ARRAY:
+                return preProcessArraySchema(schema);
+            case MAP:
+                return preProcessMapSchema(schema);
+            case STRUCT:
+                return preProcessStructSchema(schema);
+            default:
+                return schema;
+        }
+    }
+
+    private Schema preProcessArraySchema(final Schema schema) {
+        final Schema valSchema = preProcessSchema(schema.valueSchema());
+        return copySchemaBasics(schema, SchemaBuilder.array(valSchema)).build();
+    }
+
+    private Schema preProcessMapSchema(final Schema schema) {
+        final Schema keySchema = schema.keySchema();
+        final Schema valueSchema = schema.valueSchema();
+        final String keyName = keySchema.name() == null ? keySchema.type().name() : keySchema.name();
+        final String valueName = valueSchema.name() == null ? valueSchema.type().name() : valueSchema.name();
+        final Schema preprocessedKeySchema = preProcessSchema(keySchema);
+        final Schema preprocessedValueSchema = preProcessSchema(valueSchema);
+        if (useCompactMapEntries && keySchema.type() == Schema.Type.STRING) {
+            final SchemaBuilder result = SchemaBuilder.map(preprocessedKeySchema, preprocessedValueSchema);
+            return copySchemaBasics(schema, result).build();
+        }
+        final Schema elementSchema = SchemaBuilder.struct().name(keyName + "-" + valueName)
+            .field(OpensearchSinkConnectorConstants.MAP_KEY, preprocessedKeySchema)
+            .field(OpensearchSinkConnectorConstants.MAP_VALUE, preprocessedValueSchema)
+            .build();
+        return copySchemaBasics(schema, SchemaBuilder.array(elementSchema)).build();
+    }
+
+    private Schema preProcessStructSchema(final Schema schema) {
+        final SchemaBuilder builder = copySchemaBasics(schema, SchemaBuilder.struct().name(schema.name()));
+        for (final Field field : schema.fields()) {
+            builder.field(field.name(), preProcessSchema(field.schema()));
+        }
+        return builder.build();
+    }
+
+    private SchemaBuilder copySchemaBasics(final Schema source, final SchemaBuilder target) {
+        if (source.isOptional()) {
+            target.optional();
+        }
+        if (source.defaultValue() != null && source.type() != Schema.Type.STRUCT) {
+            final Object defaultVal = preProcessValue(source.defaultValue(), source, target);
+            target.defaultValue(defaultVal);
+        }
+        return target;
+    }
+
+    // visible for testing
+    Object preProcessValue(final Object value, final Schema schema, final Schema newSchema) {
+        // Handle missing schemas and acceptable null values
+        if (schema == null) {
+            return value;
+        }
+
+        if (value == null) {
+            return preProcessNullValue(schema);
+        }
+
+        // Handle logical types
+        final String schemaName = schema.name();
+        if (schemaName != null) {
+            final Object result = preProcessLogicalValue(schemaName, value);
+            if (result != null) {
+                return result;
+            }
+        }
+
+        final Schema.Type schemaType = schema.type();
+        switch (schemaType) {
+            case ARRAY:
+                return preProcessArrayValue(value, schema, newSchema);
+            case MAP:
+                return preProcessMapValue(value, schema, newSchema);
+            case STRUCT:
+                return preProcessStructValue(value, schema, newSchema);
+            default:
+                return value;
+        }
+    }
+
+    private Object preProcessNullValue(final Schema schema) {
+        if (schema.defaultValue() != null) {
+            return schema.defaultValue();
+        }
+        if (schema.isOptional()) {
+            return null;
+        }
+        throw new DataException("null value for field that is required and has no default value");
+    }
+
+    // @returns the decoded logical value or null if this isn't a known logical type
+    private Object preProcessLogicalValue(final String schemaName, final Object value) {
+        switch (schemaName) {
+            case Decimal.LOGICAL_NAME:
+                return ((BigDecimal) value).doubleValue();
+            case Date.LOGICAL_NAME:
+            case Time.LOGICAL_NAME:
+            case Timestamp.LOGICAL_NAME:
+                return value;
+            default:
+                // User-defined type or unknown built-in
+                return null;
+        }
+    }
+
+    private Object preProcessArrayValue(final Object value, final Schema schema, final Schema newSchema) {
+        final Collection<?> collection = (Collection<?>) value;
+        final List<Object> result = new ArrayList<>();
+        for (final Object element : collection) {
+            result.add(preProcessValue(element, schema.valueSchema(), newSchema.valueSchema()));
+        }
+        return result;
+    }
+
+    private Object preProcessMapValue(final Object value, final Schema schema, final Schema newSchema) {
+        final Schema keySchema = schema.keySchema();
+        final Schema valueSchema = schema.valueSchema();
+        final Schema newValueSchema = newSchema.valueSchema();
+        final Map<?, ?> map = (Map<?, ?>) value;
+        if (useCompactMapEntries && keySchema.type() == Schema.Type.STRING) {
+            final Map<Object, Object> processedMap = new HashMap<>();
+            for (final Map.Entry<?, ?> entry : map.entrySet()) {
+                processedMap.put(
+                    preProcessValue(entry.getKey(), keySchema, newSchema.keySchema()),
+                    preProcessValue(entry.getValue(), valueSchema, newValueSchema)
+                );
+            }
+            return processedMap;
+        }
+        final List<Struct> mapStructs = new ArrayList<>();
+        for (final Map.Entry<?, ?> entry : map.entrySet()) {
+            final Struct mapStruct = new Struct(newValueSchema);
+            final Schema mapKeySchema = newValueSchema.field(OpensearchSinkConnectorConstants.MAP_KEY).schema();
+            final Schema mapValueSchema = newValueSchema.field(OpensearchSinkConnectorConstants.MAP_VALUE).schema();
+            mapStruct.put(
+                OpensearchSinkConnectorConstants.MAP_KEY,
+                preProcessValue(entry.getKey(), keySchema, mapKeySchema));
+            mapStruct.put(
+                OpensearchSinkConnectorConstants.MAP_VALUE,
+                preProcessValue(entry.getValue(), valueSchema, mapValueSchema));
+            mapStructs.add(mapStruct);
+        }
+        return mapStructs;
+    }
+
+    private Object preProcessStructValue(final Object value, final Schema schema, final Schema newSchema) {
+        final Struct struct = (Struct) value;
+        final Struct newStruct = new Struct(newSchema);
+        for (final Field field : schema.fields()) {
+            final Schema newFieldSchema = newSchema.field(field.name()).schema();
+            final Object converted = preProcessValue(struct.get(field), field.schema(), newFieldSchema);
+            newStruct.put(field.name(), converted);
+        }
+        return newStruct;
+    }
+
+    public enum BehaviorOnNullValues {
+        IGNORE,
+        DELETE,
+        FAIL;
+
+        public static final BehaviorOnNullValues DEFAULT = IGNORE;
+
+        // Want values for "behavior.on.null.values" property to be case-insensitive
+        public static final ConfigDef.Validator VALIDATOR = new ConfigDef.Validator() {
+            private final ConfigDef.ValidString validator = ConfigDef.ValidString.in(names());
+
+            @Override
+            public void ensureValid(final String name, final Object value) {
+                if (value instanceof String) {
+                    final String lowerStringValue = ((String) value).toLowerCase(Locale.ROOT);
+                    validator.ensureValid(name, lowerStringValue);
+                } else {
+                    validator.ensureValid(name, value);
+                }
+            }
+
+            // Overridden here so that ConfigDef.toEnrichedRst shows possible values correctly
+            @Override
+            public String toString() {
+                return validator.toString();
+            }
+
+        };
+
+        public static String[] names() {
+            final BehaviorOnNullValues[] behaviors = values();
+            final String[] result = new String[behaviors.length];
+
+            for (int i = 0; i < behaviors.length; i++) {
+                result[i] = behaviors[i].toString();
+            }
+
+            return result;
+        }
+
+        public static BehaviorOnNullValues forValue(final String value) {
+            return valueOf(value.toUpperCase(Locale.ROOT));
+        }
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
+}

--- a/src/main/java/io/aiven/connect/opensearch/IndexableRecord.java
+++ b/src/main/java/io/aiven/connect/opensearch/IndexableRecord.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.util.Objects;
+
+public class IndexableRecord {
+
+    public final Key key;
+    public final String payload;
+    public final Long version;
+
+    public IndexableRecord(final Key key, final String payload, final Long version) {
+        this.key = key;
+        this.version = version;
+        this.payload = payload;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final IndexableRecord that = (IndexableRecord) o;
+        return Objects.equals(key, that.key)
+            && Objects.equals(payload, that.payload)
+            && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, version, payload);
+    }
+}

--- a/src/main/java/io/aiven/connect/opensearch/Key.java
+++ b/src/main/java/io/aiven/connect/opensearch/Key.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.util.Objects;
+
+public class Key {
+
+    public final String index;
+    public final String type;
+    public final String id;
+
+    public Key(final String index, final String type, final String id) {
+        this.index = index;
+        this.type = type;
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Key that = (Key) o;
+        return Objects.equals(index, that.index)
+            && Objects.equals(type, that.type)
+            && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, type, id);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Key{%s/%s/%s}", index, type, id);
+    }
+
+}

--- a/src/main/java/io/aiven/connect/opensearch/Mapping.java
+++ b/src/main/java/io/aiven/connect/opensearch/Mapping.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.gson.JsonObject;
+
+public class Mapping {
+
+    /**
+     * Create an explicit mapping.
+     *
+     * @param client The client to connect to Elasticsearch.
+     * @param index  The index to write to Elasticsearch.
+     * @param type   The type to create mapping for.
+     * @param schema The schema used to infer mapping.
+     * @throws IOException from underlying JestClient
+     */
+    public static void createMapping(
+        final OpensearchClient client,
+        final String index,
+        final String type,
+        final Schema schema
+    ) throws IOException {
+        client.createMapping(index, type, schema);
+    }
+
+    /**
+     * Get the JSON mapping for given index and type. Returns {@code null} if it does not exist.
+     */
+    public static JsonObject getMapping(final OpensearchClient client, final String index, final String type)
+        throws IOException {
+        return client.getMapping(index, type);
+    }
+
+    /**
+     * Infer mapping from the provided schema.
+     *
+     * @param schema The schema used to infer mapping.
+     */
+    public static JsonNode inferMapping(final OpensearchClient client, final Schema schema) {
+        if (schema == null) {
+            throw new DataException("Cannot infer mapping without schema.");
+        }
+
+        // Handle logical types
+        final JsonNode logicalConversion = inferLogicalMapping(schema);
+        if (logicalConversion != null) {
+            return logicalConversion;
+        }
+
+        final Schema.Type schemaType = schema.type();
+        final ObjectNode properties = JsonNodeFactory.instance.objectNode();
+        final ObjectNode fields = JsonNodeFactory.instance.objectNode();
+        switch (schemaType) {
+            case ARRAY:
+                return inferMapping(client, schema.valueSchema());
+            case MAP:
+                properties.set("properties", fields);
+                fields.set(OpensearchSinkConnectorConstants.MAP_KEY, inferMapping(client, schema.keySchema()));
+                fields.set(OpensearchSinkConnectorConstants.MAP_VALUE, inferMapping(client, schema.valueSchema()));
+                return properties;
+            case STRUCT:
+                properties.set("properties", fields);
+                for (final Field field : schema.fields()) {
+                    fields.set(field.name(), inferMapping(client, field.schema()));
+                }
+                return properties;
+            default:
+                final String esType = getOpensearchType(client, schemaType);
+                return inferPrimitive(esType, schema.defaultValue());
+        }
+    }
+
+    // visible for testing
+    protected static String getOpensearchType(final OpensearchClient client,
+                                              final Schema.Type schemaType) {
+        switch (schemaType) {
+            case BOOLEAN:
+                return OpensearchSinkConnectorConstants.BOOLEAN_TYPE;
+            case INT8:
+                return OpensearchSinkConnectorConstants.BYTE_TYPE;
+            case INT16:
+                return OpensearchSinkConnectorConstants.SHORT_TYPE;
+            case INT32:
+                return OpensearchSinkConnectorConstants.INTEGER_TYPE;
+            case INT64:
+                return OpensearchSinkConnectorConstants.LONG_TYPE;
+            case FLOAT32:
+                return OpensearchSinkConnectorConstants.FLOAT_TYPE;
+            case FLOAT64:
+                return OpensearchSinkConnectorConstants.DOUBLE_TYPE;
+            case STRING:
+                switch (client.getVersion()) {
+                    case OS_V1:
+                    default:
+                        return OpensearchSinkConnectorConstants.TEXT_TYPE;
+                }
+            case BYTES:
+                return OpensearchSinkConnectorConstants.BINARY_TYPE;
+            default:
+                return null;
+        }
+    }
+
+    private static JsonNode inferLogicalMapping(final Schema schema) {
+        final String schemaName = schema.name();
+        final Object defaultValue = schema.defaultValue();
+        if (schemaName == null) {
+            return null;
+        }
+
+        switch (schemaName) {
+            case Date.LOGICAL_NAME:
+            case Time.LOGICAL_NAME:
+            case Timestamp.LOGICAL_NAME:
+                return inferPrimitive(OpensearchSinkConnectorConstants.DATE_TYPE, defaultValue);
+            case Decimal.LOGICAL_NAME:
+                return inferPrimitive(OpensearchSinkConnectorConstants.DOUBLE_TYPE, defaultValue);
+            default:
+                // User-defined type or unknown built-in
+                return null;
+        }
+    }
+
+    private static JsonNode inferPrimitive(final String type, final Object defaultValue) {
+        if (type == null) {
+            throw new ConnectException("Invalid primitive type.");
+        }
+
+        final ObjectNode obj = JsonNodeFactory.instance.objectNode();
+        obj.set("type", JsonNodeFactory.instance.textNode(type));
+        if (type.equals(OpensearchSinkConnectorConstants.TEXT_TYPE)) {
+            addTextMapping(obj);
+        }
+        JsonNode defaultValueNode = null;
+        if (defaultValue != null) {
+            switch (type) {
+                case OpensearchSinkConnectorConstants.BYTE_TYPE:
+                    defaultValueNode = JsonNodeFactory.instance.numberNode((byte) defaultValue);
+                    break;
+                case OpensearchSinkConnectorConstants.SHORT_TYPE:
+                    defaultValueNode = JsonNodeFactory.instance.numberNode((short) defaultValue);
+                    break;
+                case OpensearchSinkConnectorConstants.INTEGER_TYPE:
+                    defaultValueNode = JsonNodeFactory.instance.numberNode((int) defaultValue);
+                    break;
+                case OpensearchSinkConnectorConstants.LONG_TYPE:
+                    defaultValueNode = JsonNodeFactory.instance.numberNode((long) defaultValue);
+                    break;
+                case OpensearchSinkConnectorConstants.FLOAT_TYPE:
+                    defaultValueNode = JsonNodeFactory.instance.numberNode((float) defaultValue);
+                    break;
+                case OpensearchSinkConnectorConstants.DOUBLE_TYPE:
+                    defaultValueNode = JsonNodeFactory.instance.numberNode((double) defaultValue);
+                    break;
+                case OpensearchSinkConnectorConstants.STRING_TYPE:
+                case OpensearchSinkConnectorConstants.TEXT_TYPE:
+                    defaultValueNode = JsonNodeFactory.instance.textNode((String) defaultValue);
+                    break;
+                case OpensearchSinkConnectorConstants.BINARY_TYPE:
+                    defaultValueNode = JsonNodeFactory.instance.binaryNode(bytes(defaultValue));
+                    break;
+                case OpensearchSinkConnectorConstants.BOOLEAN_TYPE:
+                    defaultValueNode = JsonNodeFactory.instance.booleanNode((boolean) defaultValue);
+                    break;
+                case OpensearchSinkConnectorConstants.DATE_TYPE:
+                    defaultValueNode = JsonNodeFactory.instance.numberNode((long) defaultValue);
+                    break;
+                default:
+                    throw new DataException("Invalid primitive type.");
+            }
+        }
+        if (defaultValueNode != null) {
+            obj.set("null_value", defaultValueNode);
+        }
+        return obj;
+    }
+
+    private static void addTextMapping(final ObjectNode obj) {
+        // Add additional mapping for indexing, per https://www.elastic.co/blog/strings-are-dead-long-live-strings
+        final ObjectNode keyword = JsonNodeFactory.instance.objectNode();
+        keyword.set("type", JsonNodeFactory.instance.textNode(OpensearchSinkConnectorConstants.KEYWORD_TYPE));
+        keyword.set("ignore_above", JsonNodeFactory.instance.numberNode(256));
+        final ObjectNode fields = JsonNodeFactory.instance.objectNode();
+        fields.set("keyword", keyword);
+        obj.set("fields", fields);
+    }
+
+    private static byte[] bytes(final Object value) {
+        final byte[] bytes;
+        if (value instanceof ByteBuffer) {
+            final ByteBuffer buffer = ((ByteBuffer) value).slice();
+            bytes = new byte[buffer.remaining()];
+            buffer.get(bytes);
+        } else if (value instanceof byte[]) {
+            bytes = (byte[]) value;
+        } else {
+            throw new RuntimeException(String.format("Unsupported type: %s", value.getClass()));
+        }
+        return bytes;
+    }
+
+}

--- a/src/main/java/io/aiven/connect/opensearch/OpensearchClient.java
+++ b/src/main/java/io/aiven/connect/opensearch/OpensearchClient.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.kafka.connect.data.Schema;
+
+import io.aiven.connect.opensearch.bulk.BulkRequest;
+import io.aiven.connect.opensearch.bulk.BulkResponse;
+
+import com.google.gson.JsonObject;
+
+public interface OpensearchClient extends AutoCloseable {
+
+    enum Version {
+        OS_V1
+    }
+
+    /**
+     * Gets the Elasticsearch version.
+     *
+     * @return the version, not null
+     */
+    Version getVersion();
+
+    /**
+     * Creates indices.
+     *
+     * @param indices the set of index names to create, not null
+     */
+    void createIndices(Set<String> indices);
+
+    /**
+     * Creates an explicit mapping.
+     *
+     * @param index  the index to write
+     * @param type   the type for which to create the mapping
+     * @param schema the schema used to infer the mapping
+     * @throws IOException if the client cannot execute the request
+     */
+    void createMapping(String index, String type, Schema schema) throws IOException;
+
+    /**
+     * Gets the JSON mapping for the given index and type. Returns {@code null} if it does not exist.
+     *
+     * @param index the index
+     * @param type  the type
+     * @throws IOException if the client cannot execute the request
+     */
+    JsonObject getMapping(String index, String type) throws IOException;
+
+    /**
+     * Creates a bulk request for the list of {@link IndexableRecord} records.
+     *
+     * @param batch the list of records
+     * @return the bulk request
+     */
+    BulkRequest createBulkRequest(List<IndexableRecord> batch);
+
+    /**
+     * Executes a bulk action.
+     *
+     * @param bulk the bulk request
+     * @return the bulk response
+     * @throws IOException if the client cannot execute the request
+     */
+    BulkResponse executeBulk(BulkRequest bulk) throws IOException;
+
+    /**
+     * Executes a search.
+     *
+     * @param query the search query
+     * @param index the index to search
+     * @param type  the type to search
+     * @return the search result
+     * @throws IOException if the client cannot execute the request
+     */
+    JsonObject search(String query, String index, String type) throws IOException;
+
+    /**
+     * Shuts down the client.
+     */
+    void close() throws IOException;
+}

--- a/src/main/java/io/aiven/connect/opensearch/OpensearchSinkConnector.java
+++ b/src/main/java/io/aiven/connect/opensearch/OpensearchSinkConnector.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkConnector;
+
+public class OpensearchSinkConnector extends SinkConnector {
+
+    private Map<String, String> configProperties;
+
+    @Override
+    public String version() {
+        return Version.getVersion();
+    }
+
+    @Override
+    public void start(final Map<String, String> props) throws ConnectException {
+        try {
+            configProperties = props;
+            // validation
+            new OpensearchSinkConnectorConfig(props);
+        } catch (final ConfigException e) {
+            throw new ConnectException(
+                "Couldn't start ElasticsearchSinkConnector due to configuration error",
+                e
+            );
+        }
+    }
+
+    @Override
+    public Class<? extends Task> taskClass() {
+        return OpensearchSinkTask.class;
+    }
+
+    @Override
+    public List<Map<String, String>> taskConfigs(final int maxTasks) {
+        final List<Map<String, String>> taskConfigs = new ArrayList<>();
+        final Map<String, String> taskProps = new HashMap<>();
+        taskProps.putAll(configProperties);
+        for (int i = 0; i < maxTasks; i++) {
+            taskConfigs.add(taskProps);
+        }
+        return taskConfigs;
+    }
+
+    @Override
+    public void stop() throws ConnectException {
+
+    }
+
+    @Override
+    public ConfigDef config() {
+        return OpensearchSinkConnectorConfig.CONFIG;
+    }
+}

--- a/src/main/java/io/aiven/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Width;
+
+import io.aiven.connect.opensearch.bulk.BulkProcessor;
+
+public class OpensearchSinkConnectorConfig extends AbstractConfig {
+
+    public static final String CONNECTION_URL_CONFIG = "connection.url";
+    private static final String CONNECTION_URL_DOC =
+        "List of Opensearch HTTP connection URLs e.g. ``http://eshost1:9200,"
+            + "http://eshost2:9200``.";
+    public static final String CONNECTION_USERNAME_CONFIG = "connection.username";
+    private static final String CONNECTION_USERNAME_DOC =
+        "The username used to authenticate with Opensearch. "
+            + "The default is the null, and authentication will only be performed if "
+            + " both the username and password are non-null.";
+    public static final String CONNECTION_PASSWORD_CONFIG = "connection.password";
+    private static final String CONNECTION_PASSWORD_DOC =
+        "The password used to authenticate with Opensearch. "
+            + "The default is the null, and authentication will only be performed if "
+            + " both the username and password are non-null.";
+    public static final String BATCH_SIZE_CONFIG = "batch.size";
+    private static final String BATCH_SIZE_DOC =
+        "The number of records to process as a batch when writing to Opensearch.";
+    public static final String MAX_IN_FLIGHT_REQUESTS_CONFIG = "max.in.flight.requests";
+    private static final String MAX_IN_FLIGHT_REQUESTS_DOC =
+        "The maximum number of indexing requests that can be in-flight to Opensearch before "
+            + "blocking further requests.";
+    public static final String MAX_BUFFERED_RECORDS_CONFIG = "max.buffered.records";
+    private static final String MAX_BUFFERED_RECORDS_DOC =
+        "The maximum number of records each task will buffer before blocking acceptance of more "
+            + "records. This config can be used to limit the memory usage for each task.";
+    public static final String LINGER_MS_CONFIG = "linger.ms";
+    private static final String LINGER_MS_DOC =
+        "Linger time in milliseconds for batching.\n"
+            + "Records that arrive in between request transmissions are batched into a single bulk "
+            + "indexing request, based on the ``" + BATCH_SIZE_CONFIG + "`` configuration. Normally "
+            + "this only occurs under load when records arrive faster than they can be sent out. "
+            + "However it may be desirable to reduce the number of requests even under light load and "
+            + "benefit from bulk indexing. This setting helps accomplish that - when a pending batch is"
+            + " not full, rather than immediately sending it out the task will wait up to the given "
+            + "delay to allow other records to be added so that they can be batched into a single "
+            + "request.";
+    public static final String FLUSH_TIMEOUT_MS_CONFIG = "flush.timeout.ms";
+    private static final String FLUSH_TIMEOUT_MS_DOC =
+        "The timeout in milliseconds to use for periodic flushing, and when waiting for buffer "
+            + "space to be made available by completed requests as records are added. If this timeout "
+            + "is exceeded the task will fail.";
+    public static final String MAX_RETRIES_CONFIG = "max.retries";
+    private static final String MAX_RETRIES_DOC =
+        "The maximum number of retries that are allowed for failed indexing requests. If the retry "
+            + "attempts are exhausted the task will fail.";
+    public static final String RETRY_BACKOFF_MS_CONFIG = "retry.backoff.ms";
+    private static final String RETRY_BACKOFF_MS_DOC =
+        "How long to wait in milliseconds before attempting the first retry of a failed indexing "
+            + "request. Upon a failure, this connector may wait up to twice as long as the previous "
+            + "wait, up to the maximum number of retries. "
+            + "This avoids retrying in a tight loop under failure scenarios.";
+
+    public static final String TYPE_NAME_CONFIG = "type.name";
+    private static final String TYPE_NAME_DOC = "The Opensearch type name to use when indexing.";
+
+    @Deprecated
+    public static final String TOPIC_INDEX_MAP_CONFIG = "topic.index.map";
+    private static final String TOPIC_INDEX_MAP_DOC =
+        "This option is now deprecated. A future version may remove it completely. Please use "
+            + "single message transforms, such as RegexRouter, to map topic names to index names.\n"
+            + "A map from Kafka topic name to the destination Opensearch index, represented as "
+            + "a list of ``topic:index`` pairs.";
+    public static final String KEY_IGNORE_CONFIG = "key.ignore";
+    public static final String TOPIC_KEY_IGNORE_CONFIG = "topic.key.ignore";
+    public static final String SCHEMA_IGNORE_CONFIG = "schema.ignore";
+    public static final String TOPIC_SCHEMA_IGNORE_CONFIG = "topic.schema.ignore";
+    public static final String DROP_INVALID_MESSAGE_CONFIG = "drop.invalid.message";
+
+    private static final String KEY_IGNORE_DOC =
+        "Whether to ignore the record key for the purpose of forming the Opensearch document ID."
+            + " When this is set to ``true``, document IDs will be generated as the record's "
+            + "``topic+partition+offset``.\n Note that this is a global config that applies to all "
+            + "topics, use ``" + TOPIC_KEY_IGNORE_CONFIG + "`` to override as ``true`` for specific "
+            + "topics.";
+    private static final String TOPIC_KEY_IGNORE_DOC =
+        "List of topics for which ``" + KEY_IGNORE_CONFIG + "`` should be ``true``.";
+    private static final String SCHEMA_IGNORE_CONFIG_DOC =
+        "Whether to ignore schemas during indexing. When this is set to ``true``, the record "
+            + "schema will be ignored for the purpose of registering an Opensearch mapping. "
+            + "Opensearch will infer the mapping from the data (dynamic mapping needs to be enabled "
+            + "by the user).\n Note that this is a global config that applies to all topics, use ``"
+            + TOPIC_SCHEMA_IGNORE_CONFIG + "`` to override as ``true`` for specific topics.";
+    private static final String TOPIC_SCHEMA_IGNORE_DOC =
+        "List of topics for which ``" + SCHEMA_IGNORE_CONFIG + "`` should be ``true``.";
+    private static final String DROP_INVALID_MESSAGE_DOC =
+        "Whether to drop kafka message when it cannot be converted to output message.";
+
+    public static final String COMPACT_MAP_ENTRIES_CONFIG = "compact.map.entries";
+    private static final String COMPACT_MAP_ENTRIES_DOC =
+        "Defines how map entries with string keys within record values should be written to JSON. "
+            + "When this is set to ``true``, these entries are written compactly as "
+            + "``\"entryKey\": \"entryValue\"``. "
+            + "Otherwise, map entries with string keys are written as a nested document "
+            + "``{\"key\": \"entryKey\", \"value\": \"entryValue\"}``. "
+            + "All map entries with non-string keys are always written as nested documents. "
+            + "Prior to 3.3.0, this connector always wrote map entries as nested documents, "
+            + "so set this to ``false`` to use that older behavior.";
+
+    public static final String CONNECTION_TIMEOUT_MS_CONFIG = "connection.timeout.ms";
+    public static final String READ_TIMEOUT_MS_CONFIG = "read.timeout.ms";
+    private static final String CONNECTION_TIMEOUT_MS_CONFIG_DOC = "How long to wait "
+        + "in milliseconds when establishing a connection to the Opensearch server. "
+        + "The task fails if the client fails to connect to the server in this "
+        + "interval, and will need to be restarted.";
+    private static final String READ_TIMEOUT_MS_CONFIG_DOC = "How long to wait in "
+        + "milliseconds for the Opensearch server to send a response. The task fails "
+        + "if any read operation times out, and will need to be restarted to resume "
+        + "further operations.";
+
+    public static final String BEHAVIOR_ON_NULL_VALUES_CONFIG = "behavior.on.null.values";
+    private static final String BEHAVIOR_ON_NULL_VALUES_DOC = "How to handle records with a "
+        + "non-null key and a null value (i.e. Kafka tombstone records). Valid options are "
+        + "'ignore', 'delete', and 'fail'.";
+
+    public static final String BEHAVIOR_ON_MALFORMED_DOCS_CONFIG = "behavior.on.malformed.documents";
+    private static final String BEHAVIOR_ON_MALFORMED_DOCS_DOC = "How to handle records that "
+        + "Opensearch rejects due to some malformation of the document itself, such as an index"
+        + " mapping conflict or a field name containing illegal characters. Valid options are "
+        + "'ignore', 'warn', and 'fail'.";
+
+    protected static ConfigDef baseConfigDef() {
+        final ConfigDef configDef = new ConfigDef();
+        addConnectorConfigs(configDef);
+        addConversionConfigs(configDef);
+        return configDef;
+    }
+
+    private static void addConnectorConfigs(final ConfigDef configDef) {
+        final String group = "Connector";
+        int order = 0;
+        configDef.define(
+            CONNECTION_URL_CONFIG,
+            Type.LIST,
+            Importance.HIGH,
+            CONNECTION_URL_DOC,
+            group,
+            ++order,
+            Width.LONG,
+            "Connection URLs"
+        ).define(
+            CONNECTION_USERNAME_CONFIG,
+            Type.STRING,
+            null,
+            Importance.MEDIUM,
+            CONNECTION_USERNAME_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Connection Username"
+        ).define(
+            CONNECTION_PASSWORD_CONFIG,
+            Type.PASSWORD,
+            null,
+            Importance.MEDIUM,
+            CONNECTION_PASSWORD_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Connection Password"
+        ).define(
+            BATCH_SIZE_CONFIG,
+            Type.INT,
+            2000,
+            Importance.MEDIUM,
+            BATCH_SIZE_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Batch Size"
+        ).define(
+            MAX_IN_FLIGHT_REQUESTS_CONFIG,
+            Type.INT,
+            5,
+            Importance.MEDIUM,
+            MAX_IN_FLIGHT_REQUESTS_DOC,
+            group,
+            5,
+            Width.SHORT,
+            "Max In-flight Requests"
+        ).define(
+            MAX_BUFFERED_RECORDS_CONFIG,
+            Type.INT,
+            20000,
+            Importance.LOW,
+            MAX_BUFFERED_RECORDS_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Max Buffered Records"
+        ).define(
+            LINGER_MS_CONFIG,
+            Type.LONG,
+            1L,
+            Importance.LOW,
+            LINGER_MS_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Linger (ms)"
+        ).define(
+            FLUSH_TIMEOUT_MS_CONFIG,
+            Type.LONG,
+            10000L,
+            Importance.LOW,
+            FLUSH_TIMEOUT_MS_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Flush Timeout (ms)"
+        ).define(
+            MAX_RETRIES_CONFIG,
+            Type.INT,
+            5,
+            Importance.LOW,
+            MAX_RETRIES_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Max Retries"
+        ).define(
+            RETRY_BACKOFF_MS_CONFIG,
+            Type.LONG,
+            100L,
+            Importance.LOW,
+            RETRY_BACKOFF_MS_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Retry Backoff (ms)"
+        ).define(
+            CONNECTION_TIMEOUT_MS_CONFIG,
+            Type.INT,
+            1000,
+            Importance.LOW,
+            CONNECTION_TIMEOUT_MS_CONFIG_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Connection Timeout"
+        ).define(
+            READ_TIMEOUT_MS_CONFIG,
+            Type.INT,
+            3000,
+            Importance.LOW,
+            READ_TIMEOUT_MS_CONFIG_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Read Timeout");
+    }
+
+    private static void addConversionConfigs(final ConfigDef configDef) {
+        final String group = "Data Conversion";
+        int order = 0;
+        configDef.define(
+            TYPE_NAME_CONFIG,
+            Type.STRING,
+            Importance.HIGH,
+            TYPE_NAME_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Type Name"
+        ).define(
+            KEY_IGNORE_CONFIG,
+            Type.BOOLEAN,
+            false,
+            Importance.HIGH,
+            KEY_IGNORE_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Ignore Key mode"
+        ).define(
+            SCHEMA_IGNORE_CONFIG,
+            Type.BOOLEAN,
+            false,
+            Importance.LOW,
+            SCHEMA_IGNORE_CONFIG_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Ignore Schema mode"
+        ).define(
+            COMPACT_MAP_ENTRIES_CONFIG,
+            Type.BOOLEAN,
+            true,
+            Importance.LOW,
+            COMPACT_MAP_ENTRIES_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Compact Map Entries"
+        ).define(
+            TOPIC_INDEX_MAP_CONFIG,
+            Type.LIST,
+            "",
+            Importance.LOW,
+            TOPIC_INDEX_MAP_DOC,
+            group,
+            ++order,
+            Width.LONG,
+            "Topic to Index Map"
+        ).define(
+            TOPIC_KEY_IGNORE_CONFIG,
+            Type.LIST,
+            "",
+            Importance.LOW,
+            TOPIC_KEY_IGNORE_DOC,
+            group,
+            ++order,
+            Width.LONG,
+            "Topics for 'Ignore Key' mode"
+        ).define(
+            TOPIC_SCHEMA_IGNORE_CONFIG,
+            Type.LIST,
+            "",
+            Importance.LOW,
+            TOPIC_SCHEMA_IGNORE_DOC,
+            group,
+            ++order,
+            Width.LONG,
+            "Topics for 'Ignore Schema' mode"
+        ).define(
+            DROP_INVALID_MESSAGE_CONFIG,
+            Type.BOOLEAN,
+            false,
+            Importance.LOW,
+            DROP_INVALID_MESSAGE_DOC,
+            group,
+            ++order,
+            Width.LONG,
+            "Drop invalid messages"
+        ).define(
+            BEHAVIOR_ON_NULL_VALUES_CONFIG,
+            Type.STRING,
+            DataConverter.BehaviorOnNullValues.DEFAULT.toString(),
+            DataConverter.BehaviorOnNullValues.VALIDATOR,
+            Importance.LOW,
+            BEHAVIOR_ON_NULL_VALUES_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Behavior for null-valued records"
+        ).define(
+            BEHAVIOR_ON_MALFORMED_DOCS_CONFIG,
+            Type.STRING,
+            BulkProcessor.BehaviorOnMalformedDoc.DEFAULT.toString(),
+            BulkProcessor.BehaviorOnMalformedDoc.VALIDATOR,
+            Importance.LOW,
+            BEHAVIOR_ON_MALFORMED_DOCS_DOC,
+            group,
+            ++order,
+            Width.SHORT,
+            "Behavior on malformed documents");
+    }
+
+    public static final ConfigDef CONFIG = baseConfigDef();
+
+    public OpensearchSinkConnectorConfig(final Map<String, String> props) {
+        super(CONFIG, props);
+    }
+
+    public List<String> connectionUrls() {
+        return getList(CONNECTION_URL_CONFIG).stream()
+                .map(u -> u.endsWith("/") ? u.substring(0, u.length() - 1) : u)
+                .collect(Collectors.toList());
+    }
+
+    public String typeName() {
+        return getString(OpensearchSinkConnectorConfig.TYPE_NAME_CONFIG);
+    }
+
+    public boolean ignoreKey() {
+        return getBoolean(OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG);
+    }
+
+    public boolean ignoreSchema() {
+        return getBoolean(OpensearchSinkConnectorConfig.SCHEMA_IGNORE_CONFIG);
+    }
+
+    public boolean useCompactMapEntries() {
+        return getBoolean(OpensearchSinkConnectorConfig.COMPACT_MAP_ENTRIES_CONFIG);
+    }
+
+
+    public Map<String, String> topicToIndexMap() {
+        final Map<String, String> map = new HashMap<>();
+        for (final String value : getList(OpensearchSinkConnectorConfig.TOPIC_INDEX_MAP_CONFIG)) {
+            final String[] parts = value.split(":");
+            final String topic = parts[0];
+            final String type = parts[1];
+            map.put(topic, type);
+        }
+        return map;
+    }
+
+    public Set<String> topicIgnoreKey() {
+        return Set.copyOf(getList(OpensearchSinkConnectorConfig.TOPIC_KEY_IGNORE_CONFIG));
+    }
+
+    public Set<String> topicIgnoreSchema() {
+        return Set.copyOf(getList(OpensearchSinkConnectorConfig.TOPIC_SCHEMA_IGNORE_CONFIG));
+    }
+
+    public long flushTimeoutMs() {
+        return getLong(OpensearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG);
+    }
+
+    public int maxBufferedRecords() {
+        return getInt(OpensearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG);
+    }
+
+    public int batchSize() {
+        return getInt(OpensearchSinkConnectorConfig.BATCH_SIZE_CONFIG);
+    }
+
+    public long lingerMs() {
+        return getLong(OpensearchSinkConnectorConfig.LINGER_MS_CONFIG);
+    }
+
+    public int maxInFlightRequests() {
+        return getInt(OpensearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG);
+    }
+
+    public long retryBackoffMs() {
+        return getLong(OpensearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG);
+    }
+
+    public int maxRetry() {
+        return getInt(OpensearchSinkConnectorConfig.MAX_RETRIES_CONFIG);
+    }
+
+    public boolean dropInvalidMessage() {
+        return getBoolean(OpensearchSinkConnectorConfig.DROP_INVALID_MESSAGE_CONFIG);
+    }
+
+    public DataConverter.BehaviorOnNullValues behaviorOnNullValues() {
+        return DataConverter.BehaviorOnNullValues.forValue(
+                getString(OpensearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG)
+        );
+    }
+
+    public BulkProcessor.BehaviorOnMalformedDoc behaviorOnMalformedDoc() {
+        return BulkProcessor.BehaviorOnMalformedDoc.forValue(
+                getString(OpensearchSinkConnectorConfig.BEHAVIOR_ON_MALFORMED_DOCS_CONFIG)
+        );
+    }
+
+    public static void main(final String[] args) {
+        System.out.println("=========================================");
+        System.out.println("Opensearch Sink Connector Configuration Options");
+        System.out.println("=========================================");
+        System.out.println();
+        System.out.println(CONFIG.toEnrichedRst());
+    }
+}

--- a/src/main/java/io/aiven/connect/opensearch/OpensearchSinkConnectorConstants.java
+++ b/src/main/java/io/aiven/connect/opensearch/OpensearchSinkConnectorConstants.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+public class OpensearchSinkConnectorConstants {
+    public static final String MAP_KEY = "key";
+    public static final String MAP_VALUE = "value";
+
+    public static final String BOOLEAN_TYPE = "boolean";
+    public static final String BYTE_TYPE = "byte";
+    public static final String BINARY_TYPE = "binary";
+    public static final String SHORT_TYPE = "short";
+    public static final String INTEGER_TYPE = "integer";
+    public static final String LONG_TYPE = "long";
+    public static final String FLOAT_TYPE = "float";
+    public static final String DOUBLE_TYPE = "double";
+    public static final String STRING_TYPE = "string";
+    public static final String TEXT_TYPE = "text";
+    public static final String KEYWORD_TYPE = "keyword";
+    public static final String DATE_TYPE = "date";
+}

--- a/src/main/java/io/aiven/connect/opensearch/OpensearchSinkTask.java
+++ b/src/main/java/io/aiven/connect/opensearch/OpensearchSinkTask.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpensearchSinkTask extends SinkTask {
+
+    private static final Logger log = LoggerFactory.getLogger(OpensearchSinkTask.class);
+    private OpensearchWriter writer;
+    private OpensearchClient client;
+
+    @Override
+    public String version() {
+        return Version.getVersion();
+    }
+
+    @Override
+    public void start(final Map<String, String> props) {
+        start(props, null);
+    }
+
+    @SuppressWarnings("deprecation")
+    // public for testing
+    public void start(final Map<String, String> props, final OpensearchClient client) {
+        try {
+            log.info("Starting OpensearchSinkTask.");
+
+            final OpensearchSinkConnectorConfig config = new OpensearchSinkConnectorConfig(props);
+
+            // Calculate the maximum possible backoff time ...
+            final long maxRetryBackoffMs =
+                RetryUtil.computeRetryWaitTimeInMillis(config.maxRetry(), config.retryBackoffMs());
+            if (maxRetryBackoffMs > RetryUtil.MAX_RETRY_TIME_MS) {
+                log.warn("This connector uses exponential backoff with jitter for retries, "
+                        + "and using '{}={}' and '{}={}' results in an impractical but possible maximum "
+                        + "backoff time greater than {} hours.",
+                    OpensearchSinkConnectorConfig.MAX_RETRIES_CONFIG, config.maxRetry(),
+                    OpensearchSinkConnectorConfig.RETRY_BACKOFF_MS_CONFIG, config.retryBackoffMs(),
+                    TimeUnit.MILLISECONDS.toHours(maxRetryBackoffMs));
+            }
+
+            if (client != null) {
+                this.client = client;
+            }
+
+            final OpensearchWriter.Builder builder = new OpensearchWriter.Builder(this.client)
+                .setType(config.typeName())
+                .setIgnoreKey(config.ignoreKey(), config.topicIgnoreKey())
+                .setIgnoreSchema(config.ignoreSchema(), config.topicIgnoreSchema())
+                .setCompactMapEntries(config.useCompactMapEntries())
+                .setTopicToIndexMap(config.topicToIndexMap())
+                .setFlushTimoutMs(config.flushTimeoutMs())
+                .setMaxBufferedRecords(config.maxBufferedRecords())
+                .setMaxInFlightRequests(config.maxInFlightRequests())
+                .setBatchSize(config.batchSize())
+                .setLingerMs(config.lingerMs())
+                .setRetryBackoffMs(config.retryBackoffMs())
+                .setMaxRetry(config.maxRetry())
+                .setDropInvalidMessage(config.dropInvalidMessage())
+                .setBehaviorOnNullValues(config.behaviorOnNullValues())
+                .setBehaviorOnMalformedDoc(config.behaviorOnMalformedDoc());
+
+            writer = builder.build();
+            writer.start();
+        } catch (final ConfigException e) {
+            throw new ConnectException(
+                "Couldn't start OpensearchSinkTask due to configuration error:",
+                e
+            );
+        }
+    }
+
+    @Override
+    public void open(final Collection<TopicPartition> partitions) {
+        log.debug("Opening the task for topic partitions: {}", partitions);
+        final Set<String> topics = new HashSet<>();
+        for (final TopicPartition tp : partitions) {
+            topics.add(tp.topic());
+        }
+        writer.createIndicesForTopics(topics);
+    }
+
+    @Override
+    public void put(final Collection<SinkRecord> records) throws ConnectException {
+        log.trace("Putting {} to Opensearch.", records);
+        writer.write(records);
+    }
+
+    @Override
+    public void flush(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+        log.trace("Flushing data to Opensearch with the following offsets: {}", offsets);
+        writer.flush();
+    }
+
+    @Override
+    public void close(final Collection<TopicPartition> partitions) {
+        log.debug("Closing the task for topic partitions: {}", partitions);
+    }
+
+    @Override
+    public void stop() throws ConnectException {
+        log.info("Stopping OpensearchSinkTask.");
+        if (writer != null) {
+            writer.stop();
+        }
+        if (client != null) {
+            try {
+                client.close();
+            } catch (final IOException e) {
+                throw new ConnectException(e);
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/aiven/connect/opensearch/OpensearchWriter.java
+++ b/src/main/java/io/aiven/connect/opensearch/OpensearchWriter.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import org.opensearch.common.util.set.Sets;
+
+import io.aiven.connect.opensearch.bulk.BulkProcessor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpensearchWriter {
+    private static final Logger log = LoggerFactory.getLogger(OpensearchWriter.class);
+
+    private final OpensearchClient client;
+    private final String type;
+    private final boolean ignoreKey;
+    private final Set<String> ignoreKeyTopics;
+    private final boolean ignoreSchema;
+    private final Set<String> ignoreSchemaTopics;
+    @Deprecated
+    private final Map<String, String> topicToIndexMap;
+    private final long flushTimeoutMs;
+    private final BulkProcessor<IndexableRecord, ?> bulkProcessor;
+    private final boolean dropInvalidMessage;
+    private final DataConverter.BehaviorOnNullValues behaviorOnNullValues;
+    private final DataConverter converter;
+
+    private final Set<String> existingMappings;
+    private final BulkProcessor.BehaviorOnMalformedDoc behaviorOnMalformedDoc;
+
+    OpensearchWriter(
+        final OpensearchClient client,
+        final String type,
+        final boolean useCompactMapEntries,
+        final boolean ignoreKey,
+        final Set<String> ignoreKeyTopics,
+        final boolean ignoreSchema,
+        final Set<String> ignoreSchemaTopics,
+        final Map<String, String> topicToIndexMap,
+        final long flushTimeoutMs,
+        final int maxBufferedRecords,
+        final int maxInFlightRequests,
+        final int batchSize,
+        final long lingerMs,
+        final int maxRetries,
+        final long retryBackoffMs,
+        final boolean dropInvalidMessage,
+        final DataConverter.BehaviorOnNullValues behaviorOnNullValues,
+        final BulkProcessor.BehaviorOnMalformedDoc behaviorOnMalformedDoc
+    ) {
+        this.client = client;
+        this.type = type;
+        this.ignoreKey = ignoreKey;
+        this.ignoreKeyTopics = ignoreKeyTopics;
+        this.ignoreSchema = ignoreSchema;
+        this.ignoreSchemaTopics = ignoreSchemaTopics;
+        this.topicToIndexMap = topicToIndexMap;
+        this.flushTimeoutMs = flushTimeoutMs;
+        this.dropInvalidMessage = dropInvalidMessage;
+        this.behaviorOnNullValues = behaviorOnNullValues;
+        this.converter = new DataConverter(useCompactMapEntries, behaviorOnNullValues);
+        this.behaviorOnMalformedDoc = behaviorOnMalformedDoc;
+
+        bulkProcessor = new BulkProcessor<>(
+            new SystemTime(),
+            new BulkIndexingClient(client),
+            maxBufferedRecords,
+            maxInFlightRequests,
+            batchSize,
+            lingerMs,
+            maxRetries,
+            retryBackoffMs,
+            behaviorOnMalformedDoc
+        );
+
+        existingMappings = Sets.newHashSet();
+    }
+
+    public static class Builder {
+        private final OpensearchClient client;
+        private String type;
+        private boolean useCompactMapEntries = true;
+        private boolean ignoreKey = false;
+        private Set<String> ignoreKeyTopics = Collections.emptySet();
+        private boolean ignoreSchema = false;
+        private Set<String> ignoreSchemaTopics = Collections.emptySet();
+        private Map<String, String> topicToIndexMap = new HashMap<>();
+        private long flushTimeoutMs;
+        private int maxBufferedRecords;
+        private int maxInFlightRequests;
+        private int batchSize;
+        private long lingerMs;
+        private int maxRetry;
+        private long retryBackoffMs;
+        private boolean dropInvalidMessage;
+        private DataConverter.BehaviorOnNullValues behaviorOnNullValues = DataConverter.BehaviorOnNullValues.DEFAULT;
+        private BulkProcessor.BehaviorOnMalformedDoc behaviorOnMalformedDoc;
+
+        public Builder(final OpensearchClient client) {
+            this.client = client;
+        }
+
+        public Builder setType(final String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder setIgnoreKey(final boolean ignoreKey, final Set<String> ignoreKeyTopics) {
+            this.ignoreKey = ignoreKey;
+            this.ignoreKeyTopics = ignoreKeyTopics;
+            return this;
+        }
+
+        public Builder setIgnoreSchema(final boolean ignoreSchema, final Set<String> ignoreSchemaTopics) {
+            this.ignoreSchema = ignoreSchema;
+            this.ignoreSchemaTopics = ignoreSchemaTopics;
+            return this;
+        }
+
+        public Builder setCompactMapEntries(final boolean useCompactMapEntries) {
+            this.useCompactMapEntries = useCompactMapEntries;
+            return this;
+        }
+
+        public Builder setTopicToIndexMap(final Map<String, String> topicToIndexMap) {
+            this.topicToIndexMap = topicToIndexMap;
+            return this;
+        }
+
+        public Builder setFlushTimoutMs(final long flushTimeoutMs) {
+            this.flushTimeoutMs = flushTimeoutMs;
+            return this;
+        }
+
+        public Builder setMaxBufferedRecords(final int maxBufferedRecords) {
+            this.maxBufferedRecords = maxBufferedRecords;
+            return this;
+        }
+
+        public Builder setMaxInFlightRequests(final int maxInFlightRequests) {
+            this.maxInFlightRequests = maxInFlightRequests;
+            return this;
+        }
+
+        public Builder setBatchSize(final int batchSize) {
+            this.batchSize = batchSize;
+            return this;
+        }
+
+        public Builder setLingerMs(final long lingerMs) {
+            this.lingerMs = lingerMs;
+            return this;
+        }
+
+        public Builder setMaxRetry(final int maxRetry) {
+            this.maxRetry = maxRetry;
+            return this;
+        }
+
+        public Builder setRetryBackoffMs(final long retryBackoffMs) {
+            this.retryBackoffMs = retryBackoffMs;
+            return this;
+        }
+
+        public Builder setDropInvalidMessage(final boolean dropInvalidMessage) {
+            this.dropInvalidMessage = dropInvalidMessage;
+            return this;
+        }
+
+        /**
+         * Change the behavior that the resulting {@link OpensearchWriter} will have when it
+         * encounters records with null values.
+         *
+         * @param behaviorOnNullValues Cannot be null. If in doubt, {@link DataConverter.BehaviorOnNullValues#DEFAULT}
+         *                             can be used.
+         */
+        public Builder setBehaviorOnNullValues(final DataConverter.BehaviorOnNullValues behaviorOnNullValues) {
+            this.behaviorOnNullValues =
+                Objects.requireNonNull(behaviorOnNullValues, "behaviorOnNullValues cannot be null");
+            return this;
+        }
+
+        public Builder setBehaviorOnMalformedDoc(final BulkProcessor.BehaviorOnMalformedDoc behaviorOnMalformedDoc) {
+            this.behaviorOnMalformedDoc = behaviorOnMalformedDoc;
+            return this;
+        }
+
+        public OpensearchWriter build() {
+            return new OpensearchWriter(
+                client,
+                type,
+                useCompactMapEntries,
+                ignoreKey,
+                ignoreKeyTopics,
+                ignoreSchema,
+                ignoreSchemaTopics,
+                topicToIndexMap,
+                flushTimeoutMs,
+                maxBufferedRecords,
+                maxInFlightRequests,
+                batchSize,
+                lingerMs,
+                maxRetry,
+                retryBackoffMs,
+                dropInvalidMessage,
+                behaviorOnNullValues,
+                behaviorOnMalformedDoc
+            );
+        }
+    }
+
+    public void write(final Collection<SinkRecord> records) {
+        for (final SinkRecord sinkRecord : records) {
+            // Preemptively skip records with null values if they're going to be ignored anyways
+            if (ignoreRecord(sinkRecord)) {
+                log.debug(
+                    "Ignoring sink record with key {} and null value for topic/partition/offset {}/{}/{}",
+                    sinkRecord.key(),
+                    sinkRecord.topic(),
+                    sinkRecord.kafkaPartition(),
+                    sinkRecord.kafkaOffset());
+                continue;
+            }
+
+            final String index = convertTopicToIndexName(sinkRecord.topic());
+            final boolean ignoreKey = ignoreKeyTopics.contains(sinkRecord.topic()) || this.ignoreKey;
+            final boolean ignoreSchema =
+                ignoreSchemaTopics.contains(sinkRecord.topic()) || this.ignoreSchema;
+
+            if (!ignoreSchema && !existingMappings.contains(index)) {
+                try {
+                    if (Mapping.getMapping(client, index, type) == null) {
+                        Mapping.createMapping(client, index, type, sinkRecord.valueSchema());
+                    }
+                } catch (final IOException e) {
+                    // FIXME: concurrent tasks could attempt to create the mapping and one of the requests may
+                    // fail
+                    throw new ConnectException("Failed to initialize mapping for index: " + index, e);
+                }
+                existingMappings.add(index);
+            }
+
+            tryWriteRecord(sinkRecord, index, ignoreKey, ignoreSchema);
+        }
+    }
+
+    private boolean ignoreRecord(final SinkRecord record) {
+        return record.value() == null && behaviorOnNullValues == DataConverter.BehaviorOnNullValues.IGNORE;
+    }
+
+    private void tryWriteRecord(
+        final SinkRecord sinkRecord,
+        final String index,
+        final boolean ignoreKey,
+        final boolean ignoreSchema) {
+
+        try {
+            final IndexableRecord record = converter.convertRecord(
+                sinkRecord,
+                index,
+                type,
+                ignoreKey,
+                ignoreSchema);
+            if (record != null) {
+                bulkProcessor.add(record, flushTimeoutMs);
+            }
+        } catch (final ConnectException convertException) {
+            if (dropInvalidMessage) {
+                log.error(
+                    "Can't convert record from topic {} with partition {} and offset {}. "
+                        + "Error message: {}",
+                    sinkRecord.topic(),
+                    sinkRecord.kafkaPartition(),
+                    sinkRecord.kafkaOffset(),
+                    convertException.getMessage()
+                );
+            } else {
+                throw convertException;
+            }
+        }
+    }
+
+    /**
+     * Return the expected index name for a given topic, using the configured mapping or the topic
+     * name. Elasticsearch accepts only lowercase index names
+     * (<a href="https://github.com/elastic/elasticsearch/issues/29420">ref</a>_.
+     */
+    private String convertTopicToIndexName(final String topic) {
+        final String indexOverride = topicToIndexMap.get(topic);
+        final String index = indexOverride != null ? indexOverride : topic.toLowerCase();
+        log.debug("Topic '{}' was translated as index '{}'", topic, index);
+        return index;
+    }
+
+    public void flush() {
+        bulkProcessor.flush(flushTimeoutMs);
+    }
+
+    public void start() {
+        bulkProcessor.start();
+    }
+
+    public void stop() {
+        try {
+            bulkProcessor.flush(flushTimeoutMs);
+        } catch (final Exception e) {
+            log.warn("Failed to flush during stop", e);
+        }
+        bulkProcessor.stop();
+        bulkProcessor.awaitStop(flushTimeoutMs);
+    }
+
+    public void createIndicesForTopics(final Set<String> assignedTopics) {
+        Objects.requireNonNull(assignedTopics);
+        client.createIndices(indicesForTopics(assignedTopics));
+    }
+
+    private Set<String> indicesForTopics(final Set<String> assignedTopics) {
+        final Set<String> indices = Sets.newHashSet();
+        for (final String topic : assignedTopics) {
+            indices.add(convertTopicToIndexName(topic));
+        }
+        return indices;
+    }
+
+}

--- a/src/main/java/io/aiven/connect/opensearch/RetryUtil.java
+++ b/src/main/java/io/aiven/connect/opensearch/RetryUtil.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility to compute the retry times for a given attempt, using exponential backoff.
+ *
+ * <p>The purposes of using exponential backoff is to give the ES service time to recover when it
+ * becomes overwhelmed. Adding jitter attempts to prevent a thundering herd, where large numbers
+ * of requests from many tasks overwhelm the ES service, and without randomization all tasks
+ * retry at the same time. Randomization should spread the retries out and should reduce the
+ * overall time required to complete all attempts.
+ * See <a href="https://www.awsarchitectureblog.com/2015/03/backoff.html">this blog post</a>
+ * for details.
+ */
+public class RetryUtil {
+
+    /**
+     * An arbitrary absolute maximum practical retry time.
+     */
+    public static final long MAX_RETRY_TIME_MS = TimeUnit.HOURS.toMillis(24);
+
+    /**
+     * Compute the time to sleep using exponential backoff with jitter. This method computes the
+     * normal exponential backoff as {@code initialRetryBackoffMs << retryAttempt}, and then
+     * chooses a random value between 0 and that value.
+     *
+     * @param retryAttempts         the number of previous retry attempts; must be non-negative
+     * @param initialRetryBackoffMs the initial time to wait before retrying; assumed to
+     *                              be 0 if value is negative
+     * @return the non-negative time in milliseconds to wait before the next retry attempt,
+     *         or 0 if {@code initialRetryBackoffMs} is negative
+     */
+    public static long computeRandomRetryWaitTimeInMillis(final int retryAttempts,
+                                                          final long initialRetryBackoffMs) {
+        if (initialRetryBackoffMs < 0) {
+            return 0;
+        }
+        if (retryAttempts < 0) {
+            return initialRetryBackoffMs;
+        }
+        final long maxRetryTime = computeRetryWaitTimeInMillis(retryAttempts, initialRetryBackoffMs);
+        return ThreadLocalRandom.current().nextLong(0, maxRetryTime);
+    }
+
+    /**
+     * Compute the time to sleep using exponential backoff. This method computes the normal
+     * exponential backoff as {@code initialRetryBackoffMs << retryAttempt}, bounded to always
+     * be less than {@link #MAX_RETRY_TIME_MS}.
+     *
+     * @param retryAttempts         the number of previous retry attempts; must be non-negative
+     * @param initialRetryBackoffMs the initial time to wait before retrying; assumed to be 0
+     *                              if value is negative
+     * @return the non-negative time in milliseconds to wait before the next retry attempt,
+     *         or 0 if {@code initialRetryBackoffMs} is negative
+     */
+    public static long computeRetryWaitTimeInMillis(final int retryAttempts,
+                                                    final long initialRetryBackoffMs) {
+        if (initialRetryBackoffMs < 0) {
+            return 0;
+        }
+        if (retryAttempts <= 0) {
+            return initialRetryBackoffMs;
+        }
+        if (retryAttempts > 32) {
+            // This would overflow the exponential algorithm ...
+            return MAX_RETRY_TIME_MS;
+        }
+        final long result = initialRetryBackoffMs << retryAttempts;
+        return result < 0L ? MAX_RETRY_TIME_MS : Math.min(MAX_RETRY_TIME_MS, result);
+    }
+
+
+}

--- a/src/main/java/io/aiven/connect/opensearch/Version.java
+++ b/src/main/java/io/aiven/connect/opensearch/Version.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Version {
+    private static final Logger log = LoggerFactory.getLogger(Version.class);
+    private static String version = "unknown";
+
+    private static final String VERSION_FILE = "/aiven-kafka-connect-opensearch-version.properties";
+
+    static {
+        try {
+            final Properties props = new Properties();
+            try (InputStream versionFileStream = Version.class.getResourceAsStream(VERSION_FILE)) {
+                props.load(versionFileStream);
+                version = props.getProperty("version", version).trim();
+            }
+        } catch (final Exception e) {
+            log.warn("Error while loading version:", e);
+        }
+    }
+
+    public static String getVersion() {
+        return version;
+    }
+}

--- a/src/main/java/io/aiven/connect/opensearch/bulk/BulkClient.java
+++ b/src/main/java/io/aiven/connect/opensearch/bulk/BulkClient.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch.bulk;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface BulkClient<R, B> {
+
+    B bulkRequest(List<R> batch);
+
+    BulkResponse execute(B req) throws IOException;
+
+}

--- a/src/main/java/io/aiven/connect/opensearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/aiven/connect/opensearch/bulk/BulkProcessor.java
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch.bulk;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.aiven.connect.opensearch.OpensearchSinkConnectorConfig;
+import io.aiven.connect.opensearch.RetryUtil;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @param <R> record type
+ * @param <B> bulk request type
+ */
+public class BulkProcessor<R, B> {
+
+    private static final Logger log = LoggerFactory.getLogger(BulkProcessor.class);
+
+    private static final AtomicLong BATCH_ID_GEN = new AtomicLong();
+
+    private final Time time;
+    private final BulkClient<R, B> bulkClient;
+    private final int maxBufferedRecords;
+    private final int batchSize;
+    private final long lingerMs;
+    private final int maxRetries;
+    private final long retryBackoffMs;
+    private final BehaviorOnMalformedDoc behaviorOnMalformedDoc;
+
+    private final Thread farmer;
+    private final ExecutorService executor;
+
+    // thread-safe state, can be mutated safely without synchronization,
+    // but may be part of synchronized(this) wait() conditions so need to notifyAll() on changes
+    private volatile boolean stopRequested = false;
+    private volatile boolean flushRequested = false;
+    private final AtomicReference<ConnectException> error = new AtomicReference<>();
+
+    // shared state, synchronized on (this), may be part of wait() conditions so need notifyAll() on
+    // changes
+    private final Deque<R> unsentRecords;
+    private int inFlightRecords = 0;
+
+    public BulkProcessor(
+        final Time time,
+        final BulkClient<R, B> bulkClient,
+        final int maxBufferedRecords,
+        final int maxInFlightRequests,
+        final int batchSize,
+        final long lingerMs,
+        final int maxRetries,
+        final long retryBackoffMs,
+        final BehaviorOnMalformedDoc behaviorOnMalformedDoc
+    ) {
+        this.time = time;
+        this.bulkClient = bulkClient;
+        this.maxBufferedRecords = maxBufferedRecords;
+        this.batchSize = batchSize;
+        this.lingerMs = lingerMs;
+        this.maxRetries = maxRetries;
+        this.retryBackoffMs = retryBackoffMs;
+        this.behaviorOnMalformedDoc = behaviorOnMalformedDoc;
+
+        unsentRecords = new ArrayDeque<>(maxBufferedRecords);
+
+        final ThreadFactory threadFactory = makeThreadFactory();
+        farmer = threadFactory.newThread(farmerTask());
+        executor = Executors.newFixedThreadPool(maxInFlightRequests, threadFactory);
+    }
+
+    private ThreadFactory makeThreadFactory() {
+        final AtomicInteger threadCounter = new AtomicInteger();
+        final Thread.UncaughtExceptionHandler uncaughtExceptionHandler =
+            (t, e) -> {
+                log.error("Uncaught exception in BulkProcessor thread {}", t, e);
+                failAndStop(e);
+            };
+        return new ThreadFactory() {
+            @Override
+            public Thread newThread(final Runnable r) {
+                final int threadId = threadCounter.getAndIncrement();
+                final int objId = System.identityHashCode(this);
+                final Thread t = new Thread(r, String.format("BulkProcessor@%d-%d", objId, threadId));
+                t.setDaemon(true);
+                t.setUncaughtExceptionHandler(uncaughtExceptionHandler);
+                return t;
+            }
+        };
+    }
+
+    private Runnable farmerTask() {
+        return () -> {
+            log.debug("Starting farmer task");
+            try {
+                while (!stopRequested) {
+                    submitBatchWhenReady();
+                }
+            } catch (final InterruptedException e) {
+                throw new ConnectException(e);
+            }
+            log.debug("Finished farmer task");
+        };
+    }
+
+    // Visible for testing
+    synchronized Future<BulkResponse> submitBatchWhenReady() throws InterruptedException {
+        for (long waitStartTimeMs = time.milliseconds(), elapsedMs = 0;
+             !stopRequested && !canSubmit(elapsedMs);
+             elapsedMs = time.milliseconds() - waitStartTimeMs) {
+            // when linger time has already elapsed, we still have to ensure the other submission
+            // conditions hence the wait(0) in that case
+            wait(Math.max(0, lingerMs - elapsedMs));
+        }
+        // at this point, either stopRequested or canSubmit
+        return stopRequested ? null : submitBatch();
+    }
+
+    private synchronized Future<BulkResponse> submitBatch() {
+        assert !unsentRecords.isEmpty();
+        final int batchableSize = Math.min(batchSize, unsentRecords.size());
+        final List<R> batch = new ArrayList<>(batchableSize);
+        for (int i = 0; i < batchableSize; i++) {
+            batch.add(unsentRecords.removeFirst());
+        }
+        inFlightRecords += batchableSize;
+        return executor.submit(new BulkTask(batch));
+    }
+
+    /**
+     * Submission is possible when there are unsent records and:
+     * <ul>
+     * <li>flush is called, or</li>
+     * <li>the linger timeout passes, or</li>
+     * <li>there are sufficient records to fill a batch</li>
+     * </ul>
+     */
+    private synchronized boolean canSubmit(final long elapsedMs) {
+        return !unsentRecords.isEmpty()
+            && (flushRequested || elapsedMs >= lingerMs || unsentRecords.size() >= batchSize);
+    }
+
+    /**
+     * Start concurrently creating and sending batched requests using the client.
+     */
+    public void start() {
+        farmer.start();
+    }
+
+    /**
+     * Initiate shutdown.
+     *
+     * <p>Pending buffered records are not automatically flushed, so call {@link #flush(long)} before
+     * this method if this is desirable.
+     */
+    public void stop() {
+        log.trace("stop");
+        stopRequested = true;
+        synchronized (this) {
+            // shutdown the pool under synchronization to avoid rejected submissions
+            executor.shutdown();
+            notifyAll();
+        }
+    }
+
+    /**
+     * Block upto {@code timeoutMs} till shutdown is complete.
+     *
+     * <p>This should only be called after a previous {@link #stop()} invocation.
+     */
+    public void awaitStop(final long timeoutMs) {
+        log.trace("awaitStop {}", timeoutMs);
+        assert stopRequested;
+        try {
+            if (!executor.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
+                throw new ConnectException("Timed-out waiting for executor termination");
+            }
+        } catch (final InterruptedException e) {
+            throw new ConnectException(e);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * @return whether {@link #stop()} has been requested
+     */
+    public boolean isStopping() {
+        return stopRequested;
+    }
+
+    /**
+     * @return whether any task failed with an error
+     */
+    public boolean isFailed() {
+        return error.get() != null;
+    }
+
+    /**
+     * @return {@link #isTerminal()} or {@link #isFailed()}
+     */
+    public boolean isTerminal() {
+        return isStopping() || isFailed();
+    }
+
+    /**
+     * Throw a {@link ConnectException} if {@link #isStopping()}.
+     */
+    public void throwIfStopping() {
+        if (stopRequested) {
+            throw new ConnectException("Stopping");
+        }
+    }
+
+    /**
+     * Throw the relevant {@link ConnectException} if {@link #isFailed()}.
+     */
+    public void throwIfFailed() {
+        if (isFailed()) {
+            throw error.get();
+        }
+    }
+
+    /**
+     * {@link #throwIfFailed()} and {@link #throwIfStopping()}
+     */
+    public void throwIfTerminal() {
+        throwIfFailed();
+        throwIfStopping();
+    }
+
+    /**
+     * Add a record, may block upto {@code timeoutMs} if at capacity with respect to
+     * {@code maxBufferedRecords}.
+     *
+     * <p>If any task has failed prior to or while blocked in the add, or if the timeout expires
+     * while blocked, {@link ConnectException} will be thrown.
+     */
+    public synchronized void add(final R record, final long timeoutMs) {
+        throwIfTerminal();
+
+        if (bufferedRecords() >= maxBufferedRecords) {
+            final long addStartTimeMs = time.milliseconds();
+            for (long elapsedMs = time.milliseconds() - addStartTimeMs;
+                 !isTerminal() && elapsedMs < timeoutMs && bufferedRecords() >= maxBufferedRecords;
+                 elapsedMs = time.milliseconds() - addStartTimeMs) {
+                try {
+                    wait(timeoutMs - elapsedMs);
+                } catch (final InterruptedException e) {
+                    throw new ConnectException(e);
+                }
+            }
+            throwIfTerminal();
+            if (bufferedRecords() >= maxBufferedRecords) {
+                throw new ConnectException("Add timeout expired before buffer availability");
+            }
+        }
+
+        unsentRecords.addLast(record);
+        notifyAll();
+    }
+
+    /**
+     * Request a flush and block upto {@code timeoutMs} until all pending records have been flushed.
+     *
+     * <p>If any task has failed prior to or during the flush, {@link ConnectException} will be
+     * thrown with that error.
+     */
+    public void flush(final long timeoutMs) {
+        log.trace("flush {}", timeoutMs);
+        final long flushStartTimeMs = time.milliseconds();
+        try {
+            flushRequested = true;
+            synchronized (this) {
+                notifyAll();
+                for (long elapsedMs = time.milliseconds() - flushStartTimeMs;
+                     !isTerminal() && elapsedMs < timeoutMs && bufferedRecords() > 0;
+                     elapsedMs = time.milliseconds() - flushStartTimeMs) {
+                    wait(timeoutMs - elapsedMs);
+                }
+                throwIfTerminal();
+                if (bufferedRecords() > 0) {
+                    throw new ConnectException("Flush timeout expired with unflushed records: "
+                        + bufferedRecords());
+                }
+            }
+        } catch (final InterruptedException e) {
+            throw new ConnectException(e);
+        } finally {
+            flushRequested = false;
+        }
+    }
+
+    private final class BulkTask implements Callable<BulkResponse> {
+
+        final long batchId = BATCH_ID_GEN.incrementAndGet();
+
+        final List<R> batch;
+
+        BulkTask(final List<R> batch) {
+            this.batch = batch;
+        }
+
+        @Override
+        public BulkResponse call() throws Exception {
+            final BulkResponse rsp;
+            try {
+                rsp = execute();
+            } catch (final Exception e) {
+                failAndStop(e);
+                throw e;
+            }
+            log.debug("Successfully executed batch {} of {} records", batchId, batch.size());
+            onBatchCompletion(batch.size());
+            return rsp;
+        }
+
+        private BulkResponse execute() throws Exception {
+            final B bulkReq;
+            try {
+                bulkReq = bulkClient.bulkRequest(batch);
+            } catch (final Exception e) {
+                log.error(
+                    "Failed to create bulk request from batch {} of {} records",
+                    batchId,
+                    batch.size(),
+                    e
+                );
+                throw e;
+            }
+            final int maxAttempts = maxRetries + 1;
+            for (int attempts = 1, retryAttempts = 0; true; ++attempts, ++retryAttempts) {
+                boolean retriable = true;
+                try {
+                    log.trace("Executing batch {} of {} records with attempt {}/{}",
+                        batchId, batch.size(), attempts, maxAttempts);
+                    final BulkResponse bulkRsp = bulkClient.execute(bulkReq);
+                    if (bulkRsp.isSucceeded()) {
+                        if (attempts > 1) {
+                            // We only logged failures, so log the success immediately after a failure ...
+                            log.debug("Completed batch {} of {} records with attempt {}/{}",
+                                batchId, batch.size(), attempts, maxAttempts);
+                        }
+                        return bulkRsp;
+                    } else if (responseContainsMalformedDocError(bulkRsp)) {
+                        retriable = bulkRsp.isRetriable();
+                        handleMalformedDoc(bulkRsp);
+                        return bulkRsp;
+                    } else {
+                        // for all other errors, throw the error up
+                        retriable = bulkRsp.isRetriable();
+                        throw new ConnectException("Bulk request failed: " + bulkRsp.getErrorInfo());
+                    }
+                } catch (final Exception e) {
+                    if (retriable && attempts < maxAttempts) {
+                        final long sleepTimeMs = RetryUtil.computeRandomRetryWaitTimeInMillis(retryAttempts,
+                            retryBackoffMs);
+                        log.warn("Failed to execute batch {} of {} records with attempt {}/{}, "
+                                + "will attempt retry after {} ms. Failure reason: {}",
+                            batchId, batch.size(), attempts, maxAttempts, sleepTimeMs, e.getMessage());
+                        time.sleep(sleepTimeMs);
+                    } else {
+                        log.error("Failed to execute batch {} of {} records after total of {} attempt(s)",
+                            batchId, batch.size(), attempts, e);
+                        throw e;
+                    }
+                }
+            }
+        }
+
+        private void handleMalformedDoc(final BulkResponse bulkRsp) {
+            // if the elasticsearch request failed because of a malformed document,
+            // the behavior is configurable.
+            switch (behaviorOnMalformedDoc) {
+                case IGNORE:
+                    log.debug("Encountered an illegal document error when executing batch {} of {}"
+                            + " records. Ignoring and will not index record. Error was {}",
+                        batchId, batch.size(), bulkRsp.getErrorInfo());
+                    return;
+                case WARN:
+                    log.warn("Encountered an illegal document error when executing batch {} of {}"
+                            + " records. Ignoring and will not index record. Error was {}",
+                        batchId, batch.size(), bulkRsp.getErrorInfo());
+                    return;
+                case FAIL:
+                    log.error("Encountered an illegal document error when executing batch {} of {}"
+                            + " records. Error was {} (to ignore future records like this"
+                            + " change the configuration property '%s' from '%s' to '%s').",
+                        batchId, batch.size(), bulkRsp.getErrorInfo(),
+                        OpensearchSinkConnectorConfig.BEHAVIOR_ON_MALFORMED_DOCS_CONFIG,
+                        BehaviorOnMalformedDoc.FAIL,
+                        BehaviorOnMalformedDoc.IGNORE);
+                    throw new ConnectException("Bulk request failed: " + bulkRsp.getErrorInfo());
+                default:
+                    throw new RuntimeException(String.format(
+                        "Unknown value for %s enum: %s",
+                        BehaviorOnMalformedDoc.class.getSimpleName(),
+                        behaviorOnMalformedDoc
+                    ));
+            }
+        }
+    }
+
+    private boolean responseContainsMalformedDocError(final BulkResponse bulkRsp) {
+        return bulkRsp.getErrorInfo().contains("mapper_parsing_exception")
+            || bulkRsp.getErrorInfo().contains("strict_dynamic_mapping_exception")
+            || bulkRsp.getErrorInfo().contains("illegal_argument_exception");
+    }
+
+    private synchronized void onBatchCompletion(final int batchSize) {
+        inFlightRecords -= batchSize;
+        assert inFlightRecords >= 0;
+        notifyAll();
+    }
+
+    private void failAndStop(final Throwable t) {
+        error.compareAndSet(null, toConnectException(t));
+        stop();
+    }
+
+    /**
+     * @return sum of unsent and in-flight record counts
+     */
+    public synchronized int bufferedRecords() {
+        return unsentRecords.size() + inFlightRecords;
+    }
+
+    private static ConnectException toConnectException(final Throwable t) {
+        if (t instanceof ConnectException) {
+            return (ConnectException) t;
+        } else {
+            return new ConnectException(t);
+        }
+    }
+
+    public enum BehaviorOnMalformedDoc {
+        IGNORE,
+        WARN,
+        FAIL;
+
+        public static final BehaviorOnMalformedDoc DEFAULT = FAIL;
+
+        // Want values for "behavior.on.malformed.doc" property to be case-insensitive
+        public static final ConfigDef.Validator VALIDATOR = new ConfigDef.Validator() {
+            private final ConfigDef.ValidString validator = ConfigDef.ValidString.in(names());
+
+            @Override
+            public void ensureValid(final String name, final Object value) {
+                if (value instanceof String) {
+                    final String lowerCaseStringValue = ((String) value).toLowerCase(Locale.ROOT);
+                    validator.ensureValid(name, lowerCaseStringValue);
+                } else {
+                    validator.ensureValid(name, value);
+                }
+            }
+
+            // Overridden here so that ConfigDef.toEnrichedRst shows possible values correctly
+            @Override
+            public String toString() {
+                return validator.toString();
+            }
+
+        };
+
+        public static String[] names() {
+            final BehaviorOnMalformedDoc[] behaviors = values();
+            final String[] result = new String[behaviors.length];
+
+            for (int i = 0; i < behaviors.length; i++) {
+                result[i] = behaviors[i].toString();
+            }
+
+            return result;
+        }
+
+        public static BehaviorOnMalformedDoc forValue(final String value) {
+            return valueOf(value.toUpperCase(Locale.ROOT));
+        }
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
+}

--- a/src/main/java/io/aiven/connect/opensearch/bulk/BulkRequest.java
+++ b/src/main/java/io/aiven/connect/opensearch/bulk/BulkRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Aiven Oy
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch.bulk;
+
+
+import java.util.List;
+
+import io.aiven.connect.opensearch.OpensearchClient;
+
+/**
+ * BulkRequest is a marker interface for use with
+ * {@link OpensearchClient#createBulkRequest(List)} and
+ * {@link OpensearchClient#executeBulk(BulkRequest)}.
+ * Implementations will typically hold state comprised of instances of classes that are
+ * specific to the client library.
+ */
+public interface BulkRequest {
+}

--- a/src/main/java/io/aiven/connect/opensearch/bulk/BulkResponse.java
+++ b/src/main/java/io/aiven/connect/opensearch/bulk/BulkResponse.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch.bulk;
+
+public class BulkResponse {
+
+    private static final BulkResponse SUCCESS_RESPONSE = new BulkResponse(true, false, "");
+
+    public final boolean succeeded;
+    public final boolean retriable;
+    public final String errorInfo;
+
+    private BulkResponse(final boolean succeeded, final boolean retriable, final String errorInfo) {
+        this.succeeded = succeeded;
+        this.retriable = retriable;
+        this.errorInfo = errorInfo;
+    }
+
+    public static BulkResponse success() {
+        return SUCCESS_RESPONSE;
+    }
+
+    public static BulkResponse failure(final boolean retriable, final String errorInfo) {
+        return new BulkResponse(false, retriable, errorInfo);
+    }
+
+    public boolean isSucceeded() {
+        return succeeded;
+    }
+
+    public boolean isRetriable() {
+        return retriable;
+    }
+
+    public String getErrorInfo() {
+        return errorInfo;
+    }
+
+}

--- a/src/main/resources/aiven-kafka-connect-opensearch-version.properties
+++ b/src/main/resources/aiven-kafka-connect-opensearch-version.properties
@@ -1,0 +1,17 @@
+##
+# Copyright 2019 Aiven Oy
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+version=${version ?: 'unknown'}

--- a/src/test/java/io/aiven/connect/opensearch/DataConverterTest.java
+++ b/src/test/java/io/aiven/connect/opensearch/DataConverterTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2019 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class DataConverterTest {
+
+    private DataConverter converter;
+    private String key;
+    private String topic;
+    private int partition;
+    private long offset;
+    private String index;
+    private String type;
+    private Schema schema;
+
+    @Before
+    public void setUp() {
+        converter = new DataConverter(true, DataConverter.BehaviorOnNullValues.DEFAULT);
+        key = "key";
+        topic = "topic";
+        partition = 0;
+        offset = 0;
+        index = "index";
+        type = "type";
+        schema = SchemaBuilder
+            .struct()
+            .name("struct")
+            .field("string", Schema.STRING_SCHEMA)
+            .build();
+    }
+
+    @Test
+    public void primitives() {
+        assertIdenticalAfterPreProcess(Schema.INT8_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.INT16_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.INT32_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.INT64_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.FLOAT32_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.FLOAT64_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.BOOLEAN_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.STRING_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.BYTES_SCHEMA);
+
+        assertIdenticalAfterPreProcess(Schema.OPTIONAL_INT16_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.OPTIONAL_INT32_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.OPTIONAL_INT64_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.OPTIONAL_FLOAT32_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.OPTIONAL_FLOAT64_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.OPTIONAL_BOOLEAN_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.OPTIONAL_STRING_SCHEMA);
+        assertIdenticalAfterPreProcess(Schema.OPTIONAL_BYTES_SCHEMA);
+
+        assertIdenticalAfterPreProcess(SchemaBuilder.int8().defaultValue((byte) 42).build());
+        assertIdenticalAfterPreProcess(SchemaBuilder.int16().defaultValue((short) 42).build());
+        assertIdenticalAfterPreProcess(SchemaBuilder.int32().defaultValue(42).build());
+        assertIdenticalAfterPreProcess(SchemaBuilder.int64().defaultValue(42L).build());
+        assertIdenticalAfterPreProcess(SchemaBuilder.float32().defaultValue(42.0f).build());
+        assertIdenticalAfterPreProcess(SchemaBuilder.float64().defaultValue(42.0d).build());
+        assertIdenticalAfterPreProcess(SchemaBuilder.bool().defaultValue(true).build());
+        assertIdenticalAfterPreProcess(SchemaBuilder.string().defaultValue("foo").build());
+        assertIdenticalAfterPreProcess(SchemaBuilder.bytes().defaultValue(new byte[0]).build());
+    }
+
+    private void assertIdenticalAfterPreProcess(final Schema schema) {
+        assertEquals(schema, converter.preProcessSchema(schema));
+    }
+
+    @Test
+    public void decimal() {
+        final Schema origSchema = Decimal.schema(2);
+        final Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+        assertEquals(Schema.FLOAT64_SCHEMA, preProcessedSchema);
+
+        assertEquals(0.02, converter.preProcessValue(new BigDecimal("0.02"), origSchema, preProcessedSchema));
+
+        // optional
+        assertEquals(
+            Schema.OPTIONAL_FLOAT64_SCHEMA,
+            converter.preProcessSchema(Decimal.builder(2).optional().build())
+        );
+
+        // defval
+        assertEquals(
+            SchemaBuilder.float64().defaultValue(0.00).build(),
+            converter.preProcessSchema(Decimal.builder(2).defaultValue(new BigDecimal("0.00")).build())
+        );
+    }
+
+    @Test
+    public void array() {
+        final Schema origSchema = SchemaBuilder.array(Decimal.schema(2)).schema();
+        final Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+        assertEquals(SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build(), preProcessedSchema);
+
+        assertEquals(
+            Arrays.asList(0.02, 0.42),
+            converter.preProcessValue(
+                Arrays.asList(
+                    new BigDecimal("0.02"), new BigDecimal("0.42")
+                ),
+                origSchema,
+                preProcessedSchema
+            )
+        );
+
+        // optional
+        assertEquals(
+            SchemaBuilder.array(preProcessedSchema.valueSchema()).optional().build(),
+            converter.preProcessSchema(SchemaBuilder.array(Decimal.schema(2)).optional().build())
+        );
+
+        // defval
+        assertEquals(
+            SchemaBuilder.array(preProcessedSchema.valueSchema()).defaultValue(Collections.emptyList()).build(),
+            converter.preProcessSchema(
+                SchemaBuilder.array(Decimal.schema(2))
+                    .defaultValue(Collections.emptyList()).build()
+            )
+        );
+    }
+
+    @Test
+    public void map() {
+        final Schema origSchema = SchemaBuilder.map(Schema.INT32_SCHEMA, Decimal.schema(2)).build();
+        final Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+        assertEquals(
+            SchemaBuilder.array(
+                SchemaBuilder.struct().name(Schema.INT32_SCHEMA.type().name() + "-" + Decimal.LOGICAL_NAME)
+                    .field(OpensearchSinkConnectorConstants.MAP_KEY, Schema.INT32_SCHEMA)
+                    .field(OpensearchSinkConnectorConstants.MAP_VALUE, Schema.FLOAT64_SCHEMA)
+                    .build()
+            ).build(),
+            preProcessedSchema
+        );
+
+        final Map<Object, Object> origValue = new HashMap<>();
+        origValue.put(1, new BigDecimal("0.02"));
+        origValue.put(2, new BigDecimal("0.42"));
+        assertEquals(
+            new HashSet<>(Arrays.asList(
+                new Struct(preProcessedSchema.valueSchema())
+                    .put(OpensearchSinkConnectorConstants.MAP_KEY, 1)
+                    .put(OpensearchSinkConnectorConstants.MAP_VALUE, 0.02),
+                new Struct(preProcessedSchema.valueSchema())
+                    .put(OpensearchSinkConnectorConstants.MAP_KEY, 2)
+                    .put(OpensearchSinkConnectorConstants.MAP_VALUE, 0.42)
+            )),
+            new HashSet<>((List<?>) converter.preProcessValue(origValue, origSchema, preProcessedSchema))
+        );
+
+        // optional
+        assertEquals(
+            SchemaBuilder.array(preProcessedSchema.valueSchema()).optional().build(),
+            converter.preProcessSchema(SchemaBuilder.map(Schema.INT32_SCHEMA, Decimal.schema(2)).optional().build())
+        );
+
+        // defval
+        assertEquals(
+            SchemaBuilder.array(
+                preProcessedSchema.valueSchema())
+                .defaultValue(Collections.emptyList())
+                .build(),
+            converter.preProcessSchema(
+                SchemaBuilder.map(Schema.INT32_SCHEMA, Decimal.schema(2))
+                    .defaultValue(Collections.emptyMap())
+                    .build()
+            )
+        );
+    }
+
+    @Test
+    public void stringKeyedMapNonCompactFormat() {
+        final Schema origSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build();
+
+        final Map<Object, Object> origValue = new HashMap<>();
+        origValue.put("field1", 1);
+        origValue.put("field2", 2);
+
+        // Use the older non-compact format for map entries with string keys
+        converter = new DataConverter(false, DataConverter.BehaviorOnNullValues.DEFAULT);
+
+        final Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+        assertEquals(
+            SchemaBuilder.array(
+                SchemaBuilder.struct().name(
+                    Schema.STRING_SCHEMA.type().name()
+                        + "-"
+                        + Schema.INT32_SCHEMA.type().name()
+                ).field(OpensearchSinkConnectorConstants.MAP_KEY, Schema.STRING_SCHEMA)
+                 .field(OpensearchSinkConnectorConstants.MAP_VALUE, Schema.INT32_SCHEMA)
+                 .build()
+            ).build(),
+            preProcessedSchema
+        );
+        assertEquals(
+            new HashSet<>(Arrays.asList(
+                new Struct(preProcessedSchema.valueSchema())
+                    .put(OpensearchSinkConnectorConstants.MAP_KEY, "field1")
+                    .put(OpensearchSinkConnectorConstants.MAP_VALUE, 1),
+                new Struct(preProcessedSchema.valueSchema())
+                    .put(OpensearchSinkConnectorConstants.MAP_KEY, "field2")
+                    .put(OpensearchSinkConnectorConstants.MAP_VALUE, 2)
+            )),
+            new HashSet<>((List<?>) converter.preProcessValue(origValue, origSchema, preProcessedSchema))
+        );
+    }
+
+    @Test
+    public void stringKeyedMapCompactFormat() {
+        final Schema origSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build();
+
+        final Map<Object, Object> origValue = new HashMap<>();
+        origValue.put("field1", 1);
+        origValue.put("field2", 2);
+
+        // Use the newer compact format for map entries with string keys
+        converter = new DataConverter(true, DataConverter.BehaviorOnNullValues.DEFAULT);
+        final Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+        assertEquals(
+            SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build(),
+            preProcessedSchema
+        );
+        final HashMap<?, ?> newValue = (HashMap<?, ?>)
+            converter.preProcessValue(origValue, origSchema, preProcessedSchema);
+        assertEquals(origValue, newValue);
+    }
+
+    @Test
+    public void struct() {
+        final Schema origSchema = SchemaBuilder.struct().name("struct").field("decimal", Decimal.schema(2)).build();
+        final Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+        assertEquals(
+            SchemaBuilder.struct().name("struct").field("decimal", Schema.FLOAT64_SCHEMA).build(),
+            preProcessedSchema
+        );
+
+        assertEquals(
+            new Struct(preProcessedSchema).put("decimal", 0.02),
+            converter.preProcessValue(
+                new Struct(origSchema)
+                    .put("decimal", new BigDecimal("0.02")),
+                origSchema,
+                preProcessedSchema
+            )
+        );
+
+        // optional
+        assertEquals(
+            SchemaBuilder.struct().name("struct").field("decimal", Schema.FLOAT64_SCHEMA).optional().build(),
+            converter.preProcessSchema(
+                SchemaBuilder.struct().name("struct").field("decimal", Decimal.schema(2))
+                    .optional()
+                    .build()
+            )
+        );
+    }
+
+    @Test
+    public void optionalFieldsWithoutDefaults() {
+        // One primitive type should be enough
+        testOptionalFieldWithoutDefault(SchemaBuilder.bool());
+        // Logical types
+        testOptionalFieldWithoutDefault(Decimal.builder(2));
+        testOptionalFieldWithoutDefault(Time.builder());
+        testOptionalFieldWithoutDefault(Timestamp.builder());
+        // Complex types
+        testOptionalFieldWithoutDefault(SchemaBuilder.array(Schema.BOOLEAN_SCHEMA));
+        testOptionalFieldWithoutDefault(SchemaBuilder.struct().field("innerField", Schema.BOOLEAN_SCHEMA));
+        testOptionalFieldWithoutDefault(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.BOOLEAN_SCHEMA));
+        // Have to test maps with useCompactMapEntries set to true and set to false
+        converter = new DataConverter(false, DataConverter.BehaviorOnNullValues.DEFAULT);
+        testOptionalFieldWithoutDefault(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.BOOLEAN_SCHEMA));
+    }
+
+    private void testOptionalFieldWithoutDefault(final SchemaBuilder optionalFieldSchema) {
+        final Schema origSchema = SchemaBuilder.struct().name("struct").field(
+            "optionalField", optionalFieldSchema.optional().build()
+        ).build();
+        final Schema preProcessedSchema = converter.preProcessSchema(origSchema);
+
+        final Object preProcessedValue = converter.preProcessValue(
+            new Struct(origSchema).put("optionalField", null), origSchema, preProcessedSchema
+        );
+
+        assertEquals(new Struct(preProcessedSchema).put("optionalField", null), preProcessedValue);
+    }
+
+    @Test
+    public void ignoreOnNullValue() {
+        converter = new DataConverter(true, DataConverter.BehaviorOnNullValues.IGNORE);
+
+        final SinkRecord sinkRecord = createSinkRecordWithValue(null);
+        assertNull(converter.convertRecord(sinkRecord, index, type, false, false));
+    }
+
+    @Test
+    public void deleteOnNullValue() {
+        converter = new DataConverter(true, DataConverter.BehaviorOnNullValues.DELETE);
+
+        final SinkRecord sinkRecord = createSinkRecordWithValue(null);
+        final IndexableRecord expectedRecord = createIndexableRecordWithPayload(null);
+        final IndexableRecord actualRecord = converter.convertRecord(sinkRecord, index, type, false, false);
+
+        assertEquals(expectedRecord, actualRecord);
+    }
+
+    @Test
+    public void ignoreDeleteOnNullValueWithNullKey() {
+        converter = new DataConverter(true, DataConverter.BehaviorOnNullValues.DELETE);
+        key = null;
+
+        final SinkRecord sinkRecord = createSinkRecordWithValue(null);
+        assertNull(converter.convertRecord(sinkRecord, index, type, false, false));
+    }
+
+    @Test
+    public void failOnNullValue() {
+        converter = new DataConverter(true, DataConverter.BehaviorOnNullValues.FAIL);
+
+        final SinkRecord sinkRecord = createSinkRecordWithValue(null);
+        //FIXME asdsadasd
+        try {
+            converter.convertRecord(sinkRecord, index, type, false, false);
+            fail("should fail on null-valued record with behaviorOnNullValues = FAIL");
+        } catch (final DataException e) {
+            // expected
+        }
+    }
+
+    public SinkRecord createSinkRecordWithValue(final Object value) {
+        return new SinkRecord(topic, partition, Schema.STRING_SCHEMA, key, schema, value, offset);
+    }
+
+    public IndexableRecord createIndexableRecordWithPayload(final String payload) {
+        return new IndexableRecord(new Key(index, type, key), payload, offset);
+    }
+
+}

--- a/src/test/java/io/aiven/connect/opensearch/MappingTest.java
+++ b/src/test/java/io/aiven/connect/opensearch/MappingTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+
+import org.opensearch.test.InternalTestCluster;
+
+import com.google.gson.JsonObject;
+import org.junit.Test;
+
+public class MappingTest extends OpensearchSinkTestBase {
+
+    private static final String INDEX = "kafka-connect";
+    private static final String TYPE = "kafka-connect-type";
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMapping() throws Exception {
+        final InternalTestCluster cluster = internalCluster();
+        cluster.ensureAtLeastNumDataNodes(1);
+
+        createIndex(INDEX);
+        final Schema schema = createSchema();
+        Mapping.createMapping(client, INDEX, TYPE, schema);
+
+        final JsonObject mapping = Mapping.getMapping(client, INDEX, TYPE);
+        assertNotNull(mapping);
+        verifyMapping(schema, mapping);
+    }
+
+    protected Schema createSchema() {
+        final Schema structSchema = createInnerSchema();
+        return SchemaBuilder.struct().name("record")
+            .field("boolean", Schema.BOOLEAN_SCHEMA)
+            .field("bytes", Schema.BYTES_SCHEMA)
+            .field("int8", Schema.INT8_SCHEMA)
+            .field("int16", Schema.INT16_SCHEMA)
+            .field("int32", Schema.INT32_SCHEMA)
+            .field("int64", Schema.INT64_SCHEMA)
+            .field("float32", Schema.FLOAT32_SCHEMA)
+            .field("float64", Schema.FLOAT64_SCHEMA)
+            .field("string", Schema.STRING_SCHEMA)
+            .field("array", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
+            .field("map", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build())
+            .field("struct", structSchema)
+            .field("decimal", Decimal.schema(2))
+            .field("date", Date.SCHEMA)
+            .field("time", Time.SCHEMA)
+            .field("timestamp", Timestamp.SCHEMA)
+            .build();
+    }
+
+    private Schema createInnerSchema() {
+        return SchemaBuilder.struct().name("inner")
+            .field("boolean", Schema.BOOLEAN_SCHEMA)
+            .field("bytes", Schema.BYTES_SCHEMA)
+            .field("int8", Schema.INT8_SCHEMA)
+            .field("int16", Schema.INT16_SCHEMA)
+            .field("int32", Schema.INT32_SCHEMA)
+            .field("int64", Schema.INT64_SCHEMA)
+            .field("float32", Schema.FLOAT32_SCHEMA)
+            .field("float64", Schema.FLOAT64_SCHEMA)
+            .field("string", Schema.STRING_SCHEMA)
+            .field("array", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
+            .field("map", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build())
+            .field("decimal", Decimal.schema(2))
+            .field("date", Date.SCHEMA)
+            .field("time", Time.SCHEMA)
+            .field("timestamp", Timestamp.SCHEMA)
+            .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void verifyMapping(final Schema schema, final JsonObject mapping) throws Exception {
+        final String schemaName = schema.name();
+
+        final Object type = mapping.get("type");
+        if (schemaName != null) {
+            switch (schemaName) {
+                case Date.LOGICAL_NAME:
+                case Time.LOGICAL_NAME:
+                case Timestamp.LOGICAL_NAME:
+                    assertEquals("\"" + OpensearchSinkConnectorConstants.DATE_TYPE + "\"", type.toString());
+                    return;
+                case Decimal.LOGICAL_NAME:
+                    assertEquals("\"" + OpensearchSinkConnectorConstants.DOUBLE_TYPE + "\"", type.toString());
+                    return;
+                default:
+            }
+        }
+
+        final DataConverter converter = new DataConverter(true, DataConverter.BehaviorOnNullValues.IGNORE);
+        final Schema.Type schemaType = schema.type();
+        switch (schemaType) {
+            case ARRAY:
+                verifyMapping(schema.valueSchema(), mapping);
+                break;
+            case MAP:
+                final Schema newSchema = converter.preProcessSchema(schema);
+                final JsonObject mapProperties = mapping.get("properties").getAsJsonObject();
+                verifyMapping(
+                    newSchema.keySchema(),
+                    mapProperties.get(OpensearchSinkConnectorConstants.MAP_KEY).getAsJsonObject()
+                );
+                verifyMapping(
+                    newSchema.valueSchema(),
+                    mapProperties.get(OpensearchSinkConnectorConstants.MAP_VALUE).getAsJsonObject()
+                );
+                break;
+            case STRUCT:
+                final JsonObject properties = mapping.get("properties").getAsJsonObject();
+                for (final Field field : schema.fields()) {
+                    verifyMapping(field.schema(), properties.get(field.name()).getAsJsonObject());
+                }
+                break;
+            default:
+                assertEquals("\"" + Mapping.getOpensearchType(client, schemaType) + "\"", type.toString());
+        }
+    }
+}

--- a/src/test/java/io/aiven/connect/opensearch/OpensearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/aiven/connect/opensearch/OpensearchSinkConnectorConfigTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OpensearchSinkConnectorConfigTest {
+
+    private Map<String, String> props;
+
+    @Before
+    public void setup() {
+        props = new HashMap<>();
+        props.put(OpensearchSinkConnectorConfig.TYPE_NAME_CONFIG, OpensearchSinkTestBase.TYPE);
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "localhost");
+        props.put(OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG, "true");
+    }
+
+    @Test
+    public void testDefaultHttpTimeoutsConfig() {
+        final OpensearchSinkConnectorConfig config = new OpensearchSinkConnectorConfig(props);
+        Assert.assertEquals(
+            config.getInt(OpensearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG),
+            (Integer) 3000
+        );
+        Assert.assertEquals(
+            config.getInt(OpensearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG),
+            (Integer) 1000
+        );
+    }
+
+    @Test
+    public void testSetHttpTimeoutsConfig() {
+        props.put(OpensearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG, "10000");
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG, "15000");
+        final OpensearchSinkConnectorConfig config = new OpensearchSinkConnectorConfig(props);
+        Assert.assertEquals(
+            config.getInt(OpensearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG),
+            (Integer) 10000
+        );
+        Assert.assertEquals(
+            config.getInt(OpensearchSinkConnectorConfig.CONNECTION_TIMEOUT_MS_CONFIG),
+            (Integer) 15000
+        );
+    }
+}

--- a/src/test/java/io/aiven/connect/opensearch/OpensearchSinkTaskTest.java
+++ b/src/test/java/io/aiven/connect/opensearch/OpensearchSinkTaskTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import org.opensearch.test.InternalTestCluster;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.Test;
+
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class OpensearchSinkTaskTest extends OpensearchSinkTestBase {
+
+    private static final String TOPIC_IN_CAPS = "AnotherTopicInCaps";
+    private static final int PARTITION_113 = 113;
+    private static final TopicPartition TOPIC_IN_CAPS_PARTITION = new TopicPartition(TOPIC_IN_CAPS, PARTITION_113);
+
+    private Map<String, String> createProps() {
+        final Map<String, String> props = new HashMap<>();
+        props.put(OpensearchSinkConnectorConfig.TYPE_NAME_CONFIG, TYPE);
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "localhost");
+        props.put(OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG, "true");
+        return props;
+    }
+
+    @Test
+    public void testPutAndFlush() throws Exception {
+        final InternalTestCluster cluster = internalCluster();
+        cluster.ensureAtLeastNumDataNodes(3);
+        final Map<String, String> props = createProps();
+
+        final OpensearchSinkTask task = new OpensearchSinkTask();
+        task.start(props, client);
+        task.open(new HashSet<>(Arrays.asList(TOPIC_PARTITION, TOPIC_PARTITION2, TOPIC_PARTITION3)));
+
+        final String key = "key";
+        final Schema schema = createSchema();
+        final Struct record = createRecord(schema);
+
+        final Collection<SinkRecord> records = new ArrayList<>();
+
+        SinkRecord sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 0);
+        records.add(sinkRecord);
+
+        sinkRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1);
+        records.add(sinkRecord);
+
+        task.put(records);
+        task.flush(null);
+
+        refresh();
+
+        verifySearchResults(records, true, false);
+    }
+
+    @Test
+    public void testCreateAndWriteToIndexForTopicWithUppercaseCharacters() {
+        // We should as well test that writing a record with a previously un seen record will create
+        // an index following the required elasticsearch requirements of lowercasing.
+        final InternalTestCluster cluster = internalCluster();
+        cluster.ensureAtLeastNumDataNodes(3);
+        final Map<String, String> props = createProps();
+
+        final OpensearchSinkTask task = new OpensearchSinkTask();
+
+        final String key = "key";
+        final Schema schema = createSchema();
+        final Struct record = createRecord(schema);
+
+        final SinkRecord sinkRecord = new SinkRecord(TOPIC_IN_CAPS,
+            PARTITION_113,
+            Schema.STRING_SCHEMA,
+            key,
+            schema,
+            record,
+            0);
+
+        try {
+            task.start(props, client);
+            task.open(new HashSet<>(Collections.singletonList(TOPIC_IN_CAPS_PARTITION)));
+            task.put(Collections.singleton(sinkRecord));
+        } catch (final Exception ex) {
+            fail("A topic name not in lowercase can not be used as index name in Elasticsearch");
+        } finally {
+            task.stop();
+        }
+    }
+}

--- a/src/test/java/io/aiven/connect/opensearch/OpensearchSinkTestBase.java
+++ b/src/test/java/io/aiven/connect/opensearch/OpensearchSinkTestBase.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.http.HttpTransportSettings;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.After;
+import org.junit.Before;
+
+public class OpensearchSinkTestBase extends OpenSearchIntegTestCase {
+
+    protected static final String TYPE = "kafka-connect";
+
+    protected static final String TOPIC = "topic";
+    protected static final int PARTITION = 12;
+    protected static final int PARTITION2 = 13;
+    protected static final int PARTITION3 = 14;
+    protected static final TopicPartition TOPIC_PARTITION = new TopicPartition(TOPIC, PARTITION);
+    protected static final TopicPartition TOPIC_PARTITION2 = new TopicPartition(TOPIC, PARTITION2);
+    protected static final TopicPartition TOPIC_PARTITION3 = new TopicPartition(TOPIC, PARTITION3);
+
+    protected OpensearchClient client;
+    private DataConverter converter;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        client = null;
+        converter = new DataConverter(true, DataConverter.BehaviorOnNullValues.IGNORE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        if (client != null) {
+            client.close();
+        }
+        client = null;
+    }
+
+    protected int getPort() {
+        assertTrue("There should be at least 1 HTTP endpoint exposed in the test cluster",
+                cluster().httpAddresses().length > 0);
+        return cluster().httpAddresses()[0].getPort();
+    }
+
+    protected Struct createRecord(final Schema schema) {
+        final Struct struct = new Struct(schema);
+        struct.put("user", "Liquan");
+        struct.put("message", "trying out Elastic Search.");
+        return struct;
+    }
+
+    protected Schema createSchema() {
+        return SchemaBuilder.struct().name("record")
+                .field("user", Schema.STRING_SCHEMA)
+                .field("message", Schema.STRING_SCHEMA)
+                .build();
+    }
+
+    protected Schema createOtherSchema() {
+        return SchemaBuilder.struct().name("record")
+                .field("user", Schema.INT32_SCHEMA)
+                .build();
+    }
+
+    protected Struct createOtherRecord(final Schema schema) {
+        final Struct struct = new Struct(schema);
+        struct.put("user", 10);
+        return struct;
+    }
+
+    protected void verifySearchResults(
+            final Collection<SinkRecord> records,
+            final boolean ignoreKey,
+            final boolean ignoreSchema) throws IOException {
+        verifySearchResults(records, TOPIC, ignoreKey, ignoreSchema);
+    }
+
+    protected void verifySearchResults(
+            final Collection<?> records,
+            final String index,
+            final boolean ignoreKey,
+            final boolean ignoreSchema) throws IOException {
+        final JsonObject result = client.search("", index, null);
+
+        final JsonArray rawHits = result.getAsJsonObject("hits").getAsJsonArray("hits");
+
+        assertEquals(records.size(), rawHits.size());
+
+        final Map<String, String> hits = new HashMap<>();
+        for (int i = 0; i < rawHits.size(); ++i) {
+            final JsonObject hitData = rawHits.get(i).getAsJsonObject();
+            final String id = hitData.get("_id").getAsString();
+            final String source = hitData.get("_source").getAsJsonObject().toString();
+            hits.put(id, source);
+        }
+
+        for (final Object record : records) {
+            if (record instanceof SinkRecord) {
+                final IndexableRecord indexableRecord =
+                        converter.convertRecord((SinkRecord) record, index, TYPE, ignoreKey, ignoreSchema);
+                assertEquals(indexableRecord.payload, hits.get(indexableRecord.key.id));
+            } else {
+                assertEquals(record, hits.get("key"));
+            }
+        }
+    }
+
+    @Override
+    protected Settings nodeSettings(final int nodeOrdinal) {
+        final int randomPort = randomIntBetween(49152, 65525);
+        return Settings.builder()
+                .put(super.nodeSettings(nodeOrdinal))
+                .put(HttpTransportSettings.SETTING_HTTP_PORT.getKey(), randomPort)
+                .put("network.host", "127.0.0.1")
+                .put("transport.port", randomPort)
+                .build();
+    }
+
+}

--- a/src/test/java/io/aiven/connect/opensearch/OpensearchWriterTest.java
+++ b/src/test/java/io/aiven/connect/opensearch/OpensearchWriterTest.java
@@ -1,0 +1,542 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class OpensearchWriterTest extends OpensearchSinkTestBase {
+
+    private final String key = "key";
+    private final Schema schema = createSchema();
+    private final Struct record = createRecord(schema);
+    private final Schema otherSchema = createOtherSchema();
+    private final Struct otherRecord = createOtherRecord(otherSchema);
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private boolean ignoreKey;
+    private boolean ignoreSchema;
+
+    @Before
+    public void setUp() throws Exception {
+        ignoreKey = false;
+        ignoreSchema = false;
+
+        super.setUp();
+    }
+
+    @Test
+    public void testWriter() throws Exception {
+        final Collection<SinkRecord> records = prepareData(2);
+        final OpensearchWriter writer = initWriter(client);
+        writeDataAndRefresh(writer, records);
+
+        final Collection<SinkRecord> expected = Collections.singletonList(
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1)
+        );
+        verifySearchResults(expected);
+    }
+
+    @Test
+    public void testWriterIgnoreKey() throws Exception {
+        ignoreKey = true;
+
+        final Collection<SinkRecord> records = prepareData(2);
+        final OpensearchWriter writer = initWriter(client);
+        writeDataAndRefresh(writer, records);
+        verifySearchResults(records);
+    }
+
+    @Test
+    public void testWriterIgnoreSchema() throws Exception {
+        ignoreKey = true;
+        ignoreSchema = true;
+
+        final Collection<SinkRecord> records = prepareData(2);
+        final OpensearchWriter writer = initWriter(client);
+        writeDataAndRefresh(writer, records);
+        verifySearchResults(records);
+    }
+
+    @Test
+    public void testTopicIndexOverride() throws Exception {
+        ignoreKey = true;
+        ignoreSchema = true;
+
+        final String indexOverride = "index";
+
+        final Collection<SinkRecord> records = prepareData(2);
+        final OpensearchWriter writer = initWriter(
+            client,
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Collections.singletonMap(TOPIC, indexOverride),
+            false,
+            DataConverter.BehaviorOnNullValues.IGNORE);
+        writeDataAndRefresh(writer, records);
+        verifySearchResults(records, indexOverride);
+    }
+
+    @Test(expected = ConnectException.class)
+    public void testIncompatible() throws Exception {
+        ignoreKey = true;
+
+        final Collection<SinkRecord> records = new ArrayList<>();
+        SinkRecord sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, otherSchema, otherRecord, 0);
+        records.add(sinkRecord);
+
+        final OpensearchWriter writer = initWriter(client);
+
+        writer.write(records);
+        Thread.sleep(5000);
+        records.clear();
+
+        sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1);
+        records.add(sinkRecord);
+        writer.write(records);
+
+        writer.flush();
+        fail("should fail because of mapper_parsing_exception");
+    }
+
+    @Test
+    public void testCompatible() throws Exception {
+        ignoreKey = true;
+
+        final Collection<SinkRecord> records = new ArrayList<>();
+        final Collection<SinkRecord> expected = new ArrayList<>();
+
+        SinkRecord sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 0);
+        records.add(sinkRecord);
+        expected.add(sinkRecord);
+        sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, 1);
+        records.add(sinkRecord);
+        expected.add(sinkRecord);
+
+        final OpensearchWriter writer = initWriter(client);
+
+        writer.write(records);
+        records.clear();
+
+        sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, otherSchema, otherRecord, 2);
+        records.add(sinkRecord);
+        expected.add(sinkRecord);
+
+        sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, otherSchema, otherRecord, 3);
+        records.add(sinkRecord);
+        expected.add(sinkRecord);
+
+        writeDataAndRefresh(writer, records);
+        verifySearchResults(expected);
+    }
+
+    @Test
+    public void testSafeRedeliveryRegularKey() throws Exception {
+        final Struct value0 = new Struct(schema);
+        value0.put("user", "foo");
+        value0.put("message", "hi");
+        final SinkRecord sinkRecord0 =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value0, 0);
+
+        final Struct value1 = new Struct(schema);
+        value1.put("user", "foo");
+        value1.put("message", "bye");
+        final SinkRecord sinkRecord1 =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value1, 1);
+
+        final OpensearchWriter writer = initWriter(client);
+        writer.write(Arrays.asList(sinkRecord0, sinkRecord1));
+        writer.flush();
+
+        // write the record with earlier offset again
+        writeDataAndRefresh(writer, Collections.singleton(sinkRecord0));
+
+        // last write should have been ignored due to version conflict
+        verifySearchResults(Collections.singleton(sinkRecord1));
+    }
+
+    @Test
+    public void testSafeRedeliveryOffsetInKey() throws Exception {
+        ignoreKey = true;
+
+        final Struct value0 = new Struct(schema);
+        value0.put("user", "foo");
+        value0.put("message", "hi");
+        final SinkRecord sinkRecord0 =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value0, 0);
+
+        final Struct value1 = new Struct(schema);
+        value1.put("user", "foo");
+        value1.put("message", "bye");
+        final SinkRecord sinkRecord1 =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value1, 1);
+
+        final List<SinkRecord> records = Arrays.asList(sinkRecord0, sinkRecord1);
+
+        final OpensearchWriter writer = initWriter(client);
+        writer.write(records);
+        writer.flush();
+
+        // write them again
+        writeDataAndRefresh(writer, records);
+
+        // last write should have been ignored due to version conflict
+        verifySearchResults(records);
+    }
+
+    @Test
+    public void testMap() throws Exception {
+        final Schema structSchema = SchemaBuilder.struct().name("struct")
+            .field("map", SchemaBuilder.map(Schema.INT32_SCHEMA, Schema.STRING_SCHEMA).build())
+            .build();
+
+        final Map<Integer, String> map = new HashMap<>();
+        map.put(1, "One");
+        map.put(2, "Two");
+
+        final Struct struct = new Struct(structSchema);
+        struct.put("map", map);
+
+        final Collection<SinkRecord> records = new ArrayList<>();
+        final SinkRecord sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, structSchema, struct, 0);
+        records.add(sinkRecord);
+
+        final OpensearchWriter writer = initWriter(client);
+        writeDataAndRefresh(writer, records);
+        verifySearchResults(records);
+    }
+
+    @Test
+    public void testStringKeyedMap() throws Exception {
+        final Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build();
+
+        final Map<String, Integer> map = new HashMap<>();
+        map.put("One", 1);
+        map.put("Two", 2);
+
+        final SinkRecord sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, mapSchema, map, 0);
+
+        final OpensearchWriter writer = initWriter(client);
+        writeDataAndRefresh(writer, Collections.singletonList(sinkRecord));
+
+        final Collection<?> expectedRecords =
+            Collections.singletonList(new ObjectMapper().writeValueAsString(map));
+        verifySearchResults(expectedRecords, TOPIC);
+    }
+
+    @Test
+    public void testDecimal() throws Exception {
+        final int scale = 2;
+        final byte[] bytes = ByteBuffer.allocate(4).putInt(2).array();
+        final BigDecimal decimal = new BigDecimal(new BigInteger(bytes), scale);
+
+        final Schema structSchema = SchemaBuilder.struct().name("struct")
+            .field("decimal", Decimal.schema(scale))
+            .build();
+
+        final Struct struct = new Struct(structSchema);
+        struct.put("decimal", decimal);
+
+        final Collection<SinkRecord> records = new ArrayList<>();
+        final SinkRecord sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, structSchema, struct, 0);
+        records.add(sinkRecord);
+
+        final OpensearchWriter writer = initWriter(client);
+        writeDataAndRefresh(writer, records);
+        verifySearchResults(records);
+    }
+
+    @Test
+    public void testBytes() throws Exception {
+        final Schema structSchema = SchemaBuilder.struct().name("struct")
+            .field("bytes", SchemaBuilder.BYTES_SCHEMA)
+            .build();
+
+        final Struct struct = new Struct(structSchema);
+        struct.put("bytes", new byte[]{42});
+
+        final Collection<SinkRecord> records = new ArrayList<>();
+        final SinkRecord sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, structSchema, struct, 0);
+        records.add(sinkRecord);
+
+        final OpensearchWriter writer = initWriter(client);
+        writeDataAndRefresh(writer, records);
+        verifySearchResults(records);
+    }
+
+    @Test
+    public void testIgnoreNullValue() throws Exception {
+        final Collection<SinkRecord> records = new ArrayList<>();
+        final SinkRecord sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, null, 0);
+        records.add(sinkRecord);
+
+        final OpensearchWriter writer = initWriter(client, DataConverter.BehaviorOnNullValues.IGNORE);
+        writeDataAndRefresh(writer, records);
+        // Send an empty list of records to the verify method, since the empty record should have been
+        // skipped
+        verifySearchResults(new ArrayList<SinkRecord>());
+    }
+
+    @Test
+    public void testDeleteOnNullValue() throws Exception {
+        final String key1 = "key1";
+        final String key2 = "key2";
+
+        final OpensearchWriter writer = initWriter(client, DataConverter.BehaviorOnNullValues.DELETE);
+
+        final Collection<SinkRecord> records = new ArrayList<>();
+
+        // First, write a couple of actual (non-null-valued) records
+        final SinkRecord insertRecord1 =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key1, schema, record, 0);
+        records.add(insertRecord1);
+        final SinkRecord insertRecord2 =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key2, otherSchema, otherRecord, 1);
+        records.add(insertRecord2);
+        // Can't call writeDataAndRefresh(writer, records) since it stops the writer
+        writer.write(records);
+        writer.flush();
+        refresh();
+        // Make sure the record made it there successfully
+        verifySearchResults(records);
+
+        // Then, write a record with the same key as the first inserted record but a null value
+        final SinkRecord deleteRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key1, schema, null, 2);
+
+        // Don't want to resend the first couple of records
+        records.clear();
+        records.add(deleteRecord);
+        writeDataAndRefresh(writer, records);
+
+        // The only remaining record should be the second inserted record
+        records.clear();
+        records.add(insertRecord2);
+        verifySearchResults(records);
+    }
+
+    @Test
+    public void testIneffectiveDelete() throws Exception {
+        // Just a sanity check to make sure things don't blow up if an attempt is made to delete a
+        // record that doesn't exist in the first place
+
+        final Collection<SinkRecord> records = new ArrayList<>();
+        final SinkRecord sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, null, 0);
+        records.add(sinkRecord);
+
+        final OpensearchWriter writer = initWriter(client, DataConverter.BehaviorOnNullValues.DELETE);
+        writeDataAndRefresh(writer, records);
+        verifySearchResults(new ArrayList<SinkRecord>());
+    }
+
+    @Test
+    public void testDeleteWithNullKey() throws Exception {
+        final Collection<SinkRecord> records = new ArrayList<>();
+        final SinkRecord sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null, schema, null, 0);
+        records.add(sinkRecord);
+
+        final OpensearchWriter writer = initWriter(client, DataConverter.BehaviorOnNullValues.DELETE);
+        writeDataAndRefresh(writer, records);
+        verifySearchResults(new ArrayList<SinkRecord>());
+    }
+
+    @Test
+    public void testFailOnNullValue() throws Exception {
+        final Collection<SinkRecord> records = new ArrayList<>();
+        final SinkRecord sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, null, 0);
+        records.add(sinkRecord);
+
+        final OpensearchWriter writer = initWriter(client, DataConverter.BehaviorOnNullValues.FAIL);
+        try {
+            writeDataAndRefresh(writer, records);
+            fail("should fail because of behavior.on.null.values=fail");
+        } catch (final DataException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testInvalidRecordException() throws Exception {
+        ignoreSchema = true;
+
+        final Collection<SinkRecord> records = new ArrayList<>();
+
+        final SinkRecord sinkRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null, null, new byte[]{42}, 0);
+        records.add(sinkRecord);
+
+        final OpensearchWriter strictWriter = initWriter(client);
+
+        thrown.expect(ConnectException.class);
+        thrown.expectMessage("Key is used as document id and can not be null");
+        strictWriter.write(records);
+    }
+
+    @Test
+    public void testDropInvalidRecord() throws Exception {
+        ignoreSchema = true;
+        final Collection<SinkRecord> inputRecords = new ArrayList<>();
+        final Collection<SinkRecord> outputRecords = new ArrayList<>();
+
+        final Schema structSchema = SchemaBuilder.struct().name("struct")
+            .field("bytes", SchemaBuilder.BYTES_SCHEMA)
+            .build();
+
+        final Struct struct = new Struct(structSchema);
+        struct.put("bytes", new byte[]{42});
+
+
+        final SinkRecord invalidRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null, structSchema, struct, 0);
+        final SinkRecord validRecord =
+            new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, structSchema, struct, 1);
+
+        inputRecords.add(validRecord);
+        inputRecords.add(invalidRecord);
+
+        outputRecords.add(validRecord);
+
+        final OpensearchWriter nonStrictWriter = initWriter(client, true);
+
+        writeDataAndRefresh(nonStrictWriter, inputRecords);
+        verifySearchResults(outputRecords, ignoreKey, ignoreSchema);
+    }
+
+    private Collection<SinkRecord> prepareData(final int numRecords) {
+        final Collection<SinkRecord> records = new ArrayList<>();
+        for (int i = 0; i < numRecords; ++i) {
+            final SinkRecord sinkRecord =
+                new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, record, i);
+            records.add(sinkRecord);
+        }
+        return records;
+    }
+
+    private OpensearchWriter initWriter(final OpensearchClient client) {
+        return initWriter(client, false, DataConverter.BehaviorOnNullValues.IGNORE);
+    }
+
+    private OpensearchWriter initWriter(final OpensearchClient client, final boolean dropInvalidMessage) {
+        return initWriter(client, dropInvalidMessage, DataConverter.BehaviorOnNullValues.IGNORE);
+    }
+
+    private OpensearchWriter initWriter(
+        final OpensearchClient client,
+        final DataConverter.BehaviorOnNullValues behavior) {
+        return initWriter(client, false, behavior);
+    }
+
+    private OpensearchWriter initWriter(
+        final OpensearchClient client,
+        final boolean dropInvalidMessage,
+        final DataConverter.BehaviorOnNullValues behavior) {
+        return initWriter(
+            client,
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Collections.emptyMap(),
+            dropInvalidMessage,
+            behavior
+        );
+    }
+
+    private OpensearchWriter initWriter(
+        final OpensearchClient client,
+        final Set<String> ignoreKeyTopics,
+        final Set<String> ignoreSchemaTopics,
+        final Map<String, String> topicToIndexMap,
+        final boolean dropInvalidMessage,
+        final DataConverter.BehaviorOnNullValues behavior
+    ) {
+        final OpensearchWriter writer = new OpensearchWriter.Builder(client)
+            .setType(TYPE)
+            .setIgnoreKey(ignoreKey, ignoreKeyTopics)
+            .setIgnoreSchema(ignoreSchema, ignoreSchemaTopics)
+            .setTopicToIndexMap(topicToIndexMap)
+            .setFlushTimoutMs(10000)
+            .setMaxBufferedRecords(10000)
+            .setMaxInFlightRequests(1)
+            .setBatchSize(2)
+            .setLingerMs(1000)
+            .setRetryBackoffMs(1000)
+            .setMaxRetry(3)
+            .setDropInvalidMessage(dropInvalidMessage)
+            .setBehaviorOnNullValues(behavior)
+            .build();
+        writer.start();
+        writer.createIndicesForTopics(Collections.singleton(TOPIC));
+        return writer;
+    }
+
+    private void writeDataAndRefresh(final OpensearchWriter writer, final Collection<SinkRecord> records)
+        throws Exception {
+        writer.write(records);
+        writer.flush();
+        writer.stop();
+        refresh();
+    }
+
+    private void verifySearchResults(final Collection<SinkRecord> records) throws Exception {
+        verifySearchResults(records, ignoreKey, ignoreSchema);
+    }
+
+    private void verifySearchResults(final Collection<?> records, final String index) throws Exception {
+        verifySearchResults(records, index, ignoreKey, ignoreSchema);
+    }
+}

--- a/src/test/java/io/aiven/connect/opensearch/RetryUtilTest.java
+++ b/src/test/java/io/aiven/connect/opensearch/RetryUtilTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RetryUtilTest {
+
+    @Test
+    public void computeRetryBackoffForValidRanges() {
+        assertComputeRetryInRange(10, 10L);
+        assertComputeRetryInRange(10, 100L);
+        assertComputeRetryInRange(10, 1000L);
+        assertComputeRetryInRange(100, 1000L);
+    }
+
+    @Test
+    public void computeRetryBackoffForNegativeRetryTimes() {
+        assertComputeRetryInRange(1, -100L);
+        assertComputeRetryInRange(10, -100L);
+        assertComputeRetryInRange(100, -100L);
+    }
+
+    @Test
+    public void computeNonRandomRetryTimes() {
+        assertEquals(100L, RetryUtil.computeRetryWaitTimeInMillis(0, 100L));
+        assertEquals(200L, RetryUtil.computeRetryWaitTimeInMillis(1, 100L));
+        assertEquals(400L, RetryUtil.computeRetryWaitTimeInMillis(2, 100L));
+        assertEquals(800L, RetryUtil.computeRetryWaitTimeInMillis(3, 100L));
+        assertEquals(1600L, RetryUtil.computeRetryWaitTimeInMillis(4, 100L));
+        assertEquals(3200L, RetryUtil.computeRetryWaitTimeInMillis(5, 100L));
+    }
+
+    protected void assertComputeRetryInRange(final int retryAttempts, final long retryBackoffMs) {
+        for (int i = 0; i != 20; ++i) {
+            for (int retries = 0; retries <= retryAttempts; ++retries) {
+                final long maxResult = RetryUtil.computeRetryWaitTimeInMillis(retries, retryBackoffMs);
+                final long result = RetryUtil.computeRandomRetryWaitTimeInMillis(retries, retryBackoffMs);
+                if (retryBackoffMs < 0) {
+                    assertEquals(0, result);
+                } else {
+                    assertTrue(result >= 0L);
+                    assertTrue(result <= maxResult);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/io/aiven/connect/opensearch/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/aiven/connect/opensearch/bulk/BulkProcessorTest.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.opensearch.bulk;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.aiven.connect.opensearch.bulk.BulkProcessor.BehaviorOnMalformedDoc;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BulkProcessorTest {
+
+    private static class Expectation {
+        final List<Integer> request;
+        final BulkResponse response;
+
+        private Expectation(final List<Integer> request, final BulkResponse response) {
+            this.request = request;
+            this.response = response;
+        }
+    }
+
+    private static final class Client implements BulkClient<Integer, List<Integer>> {
+        private final Queue<Expectation> expectQ = new LinkedList<>();
+        private volatile boolean executeMetExpectations = true;
+
+        @Override
+        public List<Integer> bulkRequest(final List<Integer> batch) {
+            final List<Integer> ids = new ArrayList<>(batch.size());
+            for (final Integer id : batch) {
+                ids.add(id);
+            }
+            return ids;
+        }
+
+        public void expect(final List<Integer> ids, final BulkResponse response) {
+            expectQ.add(new Expectation(ids, response));
+        }
+
+        public boolean expectationsMet() {
+            return expectQ.isEmpty() && executeMetExpectations;
+        }
+
+        @Override
+        public BulkResponse execute(final List<Integer> request) throws IOException {
+            final Expectation expectation;
+            try {
+                expectation = expectQ.remove();
+                assertEquals(expectation.request, request);
+            } catch (final Throwable t) {
+                executeMetExpectations = false;
+                throw t;
+            }
+            executeMetExpectations &= true;
+            return expectation.response;
+        }
+    }
+
+    Client client;
+
+    @Before
+    public void createClient() {
+        client = new Client();
+    }
+
+    @After
+    public void checkClient() {
+        assertTrue(client.expectationsMet());
+    }
+
+    @Test
+    public void batchingAndLingering() throws InterruptedException, ExecutionException {
+        final int maxBufferedRecords = 100;
+        final int maxInFlightBatches = 5;
+        final int batchSize = 5;
+        final int lingerMs = 5;
+        final int maxRetries = 0;
+        final int retryBackoffMs = 0;
+        final BehaviorOnMalformedDoc behaviorOnMalformedDoc = BehaviorOnMalformedDoc.DEFAULT;
+
+        final BulkProcessor<Integer, ?> bulkProcessor = new BulkProcessor<>(
+            Time.SYSTEM,
+            client,
+            maxBufferedRecords,
+            maxInFlightBatches,
+            batchSize,
+            lingerMs,
+            maxRetries,
+            retryBackoffMs,
+            behaviorOnMalformedDoc
+        );
+
+        final int addTimeoutMs = 10;
+        bulkProcessor.add(1, addTimeoutMs);
+        bulkProcessor.add(2, addTimeoutMs);
+        bulkProcessor.add(3, addTimeoutMs);
+        bulkProcessor.add(4, addTimeoutMs);
+        bulkProcessor.add(5, addTimeoutMs);
+        bulkProcessor.add(6, addTimeoutMs);
+        bulkProcessor.add(7, addTimeoutMs);
+        bulkProcessor.add(8, addTimeoutMs);
+        bulkProcessor.add(9, addTimeoutMs);
+        bulkProcessor.add(10, addTimeoutMs);
+        bulkProcessor.add(11, addTimeoutMs);
+        bulkProcessor.add(12, addTimeoutMs);
+
+        client.expect(Arrays.asList(1, 2, 3, 4, 5), BulkResponse.success());
+        client.expect(Arrays.asList(6, 7, 8, 9, 10), BulkResponse.success());
+        client.expect(Arrays.asList(11, 12), BulkResponse.success()); // batch not full, but upon linger timeout
+        assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
+        assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
+        assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
+    }
+
+    @Test
+    public void flushing() {
+        final int maxBufferedRecords = 100;
+        final int maxInFlightBatches = 5;
+        final int batchSize = 5;
+        final int lingerMs = 100000; // super high on purpose to make sure flush is what's causing the request
+        final int maxRetries = 0;
+        final int retryBackoffMs = 0;
+        final BehaviorOnMalformedDoc behaviorOnMalformedDoc = BehaviorOnMalformedDoc.DEFAULT;
+
+        final BulkProcessor<Integer, ?> bulkProcessor = new BulkProcessor<>(
+            Time.SYSTEM,
+            client,
+            maxBufferedRecords,
+            maxInFlightBatches,
+            batchSize,
+            lingerMs,
+            maxRetries,
+            retryBackoffMs,
+            behaviorOnMalformedDoc
+        );
+
+        client.expect(Arrays.asList(1, 2, 3), BulkResponse.success());
+
+        bulkProcessor.start();
+
+        final int addTimeoutMs = 10;
+        bulkProcessor.add(1, addTimeoutMs);
+        bulkProcessor.add(2, addTimeoutMs);
+        bulkProcessor.add(3, addTimeoutMs);
+
+        assertFalse(client.expectationsMet());
+
+        final int flushTimeoutMs = 100;
+        bulkProcessor.flush(flushTimeoutMs);
+    }
+
+    @Test(expected = ConnectException.class)
+    public void addBlocksWhenBufferFull() {
+        final int maxBufferedRecords = 1;
+        final int maxInFlightBatches = 1;
+        final int batchSize = 1;
+        final int lingerMs = 10;
+        final int maxRetries = 0;
+        final int retryBackoffMs = 0;
+        final BehaviorOnMalformedDoc behaviorOnMalformedDoc = BehaviorOnMalformedDoc.DEFAULT;
+
+        final BulkProcessor<Integer, ?> bulkProcessor = new BulkProcessor<>(
+            Time.SYSTEM,
+            client,
+            maxBufferedRecords,
+            maxInFlightBatches,
+            batchSize,
+            lingerMs,
+            maxRetries,
+            retryBackoffMs,
+            behaviorOnMalformedDoc
+        );
+
+        final int addTimeoutMs = 10;
+        bulkProcessor.add(42, addTimeoutMs);
+        assertEquals(1, bulkProcessor.bufferedRecords());
+        bulkProcessor.add(43, addTimeoutMs);
+        fail();
+    }
+
+    @Test
+    public void retriableErrors() throws InterruptedException, ExecutionException {
+        final int maxBufferedRecords = 100;
+        final int maxInFlightBatches = 5;
+        final int batchSize = 2;
+        final int lingerMs = 5;
+        final int maxRetries = 3;
+        final int retryBackoffMs = 1;
+        final BehaviorOnMalformedDoc behaviorOnMalformedDoc = BehaviorOnMalformedDoc.DEFAULT;
+
+        client.expect(Arrays.asList(42, 43), BulkResponse.failure(true, "a retiable error"));
+        client.expect(Arrays.asList(42, 43), BulkResponse.failure(true, "a retriable error again"));
+        client.expect(Arrays.asList(42, 43), BulkResponse.success());
+
+        final BulkProcessor<Integer, ?> bulkProcessor = new BulkProcessor<>(
+            Time.SYSTEM,
+            client,
+            maxBufferedRecords,
+            maxInFlightBatches,
+            batchSize,
+            lingerMs,
+            maxRetries,
+            retryBackoffMs,
+            behaviorOnMalformedDoc
+        );
+
+        final int addTimeoutMs = 10;
+        bulkProcessor.add(42, addTimeoutMs);
+        bulkProcessor.add(43, addTimeoutMs);
+
+        assertTrue(bulkProcessor.submitBatchWhenReady().get().succeeded);
+    }
+
+    @Test
+    public void retriableErrorsHitMaxRetries() throws InterruptedException, ExecutionException {
+        final int maxBufferedRecords = 100;
+        final int maxInFlightBatches = 5;
+        final int batchSize = 2;
+        final int lingerMs = 5;
+        final int maxRetries = 2;
+        final int retryBackoffMs = 1;
+        final String errorInfo = "a final retriable error again";
+        final BehaviorOnMalformedDoc behaviorOnMalformedDoc = BehaviorOnMalformedDoc.DEFAULT;
+
+        client.expect(Arrays.asList(42, 43), BulkResponse.failure(true, "a retiable error"));
+        client.expect(Arrays.asList(42, 43), BulkResponse.failure(true, "a retriable error again"));
+        client.expect(Arrays.asList(42, 43), BulkResponse.failure(true, errorInfo));
+
+        final BulkProcessor<Integer, ?> bulkProcessor = new BulkProcessor<>(
+            Time.SYSTEM,
+            client,
+            maxBufferedRecords,
+            maxInFlightBatches,
+            batchSize,
+            lingerMs,
+            maxRetries,
+            retryBackoffMs,
+            behaviorOnMalformedDoc
+        );
+
+        final int addTimeoutMs = 10;
+        bulkProcessor.add(42, addTimeoutMs);
+        bulkProcessor.add(43, addTimeoutMs);
+
+        try {
+            bulkProcessor.submitBatchWhenReady().get();
+            fail();
+        } catch (final ExecutionException e) {
+            assertTrue(e.getCause().getMessage().contains(errorInfo));
+        }
+    }
+
+    @Test
+    public void unretriableErrors() throws InterruptedException {
+        final int maxBufferedRecords = 100;
+        final int maxInFlightBatches = 5;
+        final int batchSize = 2;
+        final int lingerMs = 5;
+        final int maxRetries = 3;
+        final int retryBackoffMs = 1;
+        final BehaviorOnMalformedDoc behaviorOnMalformedDoc = BehaviorOnMalformedDoc.DEFAULT;
+
+        final String errorInfo = "an unretriable error";
+        client.expect(Arrays.asList(42, 43), BulkResponse.failure(false, errorInfo));
+
+        final BulkProcessor<Integer, ?> bulkProcessor = new BulkProcessor<>(
+            Time.SYSTEM,
+            client,
+            maxBufferedRecords,
+            maxInFlightBatches,
+            batchSize,
+            lingerMs,
+            maxRetries,
+            retryBackoffMs,
+            behaviorOnMalformedDoc
+        );
+
+        final int addTimeoutMs = 10;
+        bulkProcessor.add(42, addTimeoutMs);
+        bulkProcessor.add(43, addTimeoutMs);
+
+        try {
+            bulkProcessor.submitBatchWhenReady().get();
+            fail();
+        } catch (final ExecutionException e) {
+            assertTrue(e.getCause().getMessage().contains(errorInfo));
+        }
+    }
+
+    @Test
+    public void failOnMalformedDoc() throws InterruptedException {
+        final int maxBufferedRecords = 100;
+        final int maxInFlightBatches = 5;
+        final int batchSize = 2;
+        final int lingerMs = 5;
+        final int maxRetries = 3;
+        final int retryBackoffMs = 1;
+        final BehaviorOnMalformedDoc behaviorOnMalformedDoc = BehaviorOnMalformedDoc.FAIL;
+
+        final String errorInfo =
+            " [{\"type\":\"mapper_parsing_exception\","
+                + "\"reason\":\"failed to parse\","
+                + "\"caused_by\":{\"type\":\"illegal_argument_exception\","
+                + "\"reason\":\"object\n"
+                + " field starting or ending with a [.] "
+                + "makes object resolution "
+                + "ambiguous: [avjpz{{.}}wjzse{{..}}gal9d]\"}}]";
+        client.expect(Arrays.asList(42, 43), BulkResponse.failure(false, errorInfo));
+
+        final BulkProcessor<Integer, ?> bulkProcessor = new BulkProcessor<>(
+            Time.SYSTEM,
+            client,
+            maxBufferedRecords,
+            maxInFlightBatches,
+            batchSize,
+            lingerMs,
+            maxRetries,
+            retryBackoffMs,
+            behaviorOnMalformedDoc
+        );
+
+        bulkProcessor.start();
+
+        bulkProcessor.add(42, 1);
+        bulkProcessor.add(43, 1);
+
+        try {
+            final int flushTimeoutMs = 1000;
+            bulkProcessor.flush(flushTimeoutMs);
+            fail();
+        } catch (final ConnectException e) {
+            // expected
+            assertTrue(e.getMessage().contains("mapper_parsing_exception"));
+        }
+    }
+
+    @Test
+    public void ignoreOrWarnOnMalformedDoc() throws InterruptedException {
+        final int maxBufferedRecords = 100;
+        final int maxInFlightBatches = 5;
+        final int batchSize = 2;
+        final int lingerMs = 5;
+        final int maxRetries = 3;
+        final int retryBackoffMs = 1;
+
+        // Test both IGNORE and WARN options
+        // There is no difference in logic between IGNORE and WARN, except for the logging.
+        // Test to ensure they both work the same logically
+        final List<BehaviorOnMalformedDoc> behaviorsToTest = Arrays.asList(
+            BehaviorOnMalformedDoc.WARN,
+            BehaviorOnMalformedDoc.IGNORE
+        );
+
+        for (final BehaviorOnMalformedDoc behaviorOnMalformedDoc : behaviorsToTest) {
+            final String errorInfo =
+                " [{\"type\":\"mapper_parsing_exception\",\"reason\":\"failed to parse\","
+                    + "\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"object\n"
+                    + " field starting or ending with a [.] "
+                    + "makes object resolution ambiguous: [avjpz{{.}}wjzse{{..}}gal9d]\"}}]";
+            client.expect(Arrays.asList(42, 43), BulkResponse.failure(false, errorInfo));
+
+            final BulkProcessor<Integer, ?> bulkProcessor = new BulkProcessor<>(
+                Time.SYSTEM,
+                client,
+                maxBufferedRecords,
+                maxInFlightBatches,
+                batchSize,
+                lingerMs,
+                maxRetries,
+                retryBackoffMs,
+                behaviorOnMalformedDoc
+            );
+
+            bulkProcessor.start();
+
+            bulkProcessor.add(42, 1);
+            bulkProcessor.add(43, 1);
+
+            try {
+                final int flushTimeoutMs = 1000;
+                bulkProcessor.flush(flushTimeoutMs);
+            } catch (final ConnectException e) {
+                fail(e.getMessage());
+            }
+        }
+    }
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,21 @@
+##
+# Copyright 2019 Aiven Oy
+# Copyright 2016 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+log4j.rootLogger=INFO, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+log4j.logger.org.apache.kafka=ERROR


### PR DESCRIPTION
Renamed packages and files:

- rename packages and files prefix from Elasticsearch to Opensearch
- removed the Jest client in favour of the Opensearch official client
- temporarily excluded tests for the project build

