### PR TITLE
DataConverter refactoring

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/opensearch/Key.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/Key.java
@@ -22,12 +22,10 @@ import java.util.Objects;
 public class Key {
 
     public final String index;
-    public final String type;
     public final String id;
 
-    public Key(final String index, final String type, final String id) {
+    public Key(final String index, final String id) {
         this.index = index;
-        this.type = type;
         this.id = id;
     }
 
@@ -41,18 +39,17 @@ public class Key {
         }
         final Key that = (Key) o;
         return Objects.equals(index, that.index)
-            && Objects.equals(type, that.type)
             && Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, type, id);
+        return Objects.hash(index, id);
     }
 
     @Override
     public String toString() {
-        return String.format("Key{%s/%s/%s}", index, type, id);
+        return String.format("Key{%s/%s}", index, id);
     }
 
 }

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -476,6 +476,14 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
         return getBoolean(OpensearchSinkConnectorConfig.DROP_INVALID_MESSAGE_CONFIG);
     }
 
+    public boolean ignoreKeyFor(final String topic) {
+        return ignoreKey() || topicIgnoreKey().contains(topic);
+    }
+
+    public boolean ignoreSchemaFor(final String topic) {
+        return ignoreSchema() || topicIgnoreSchema().contains(topic);
+    }
+
     public RecordConverter.BehaviorOnNullValues behaviorOnNullValues() {
         return RecordConverter.BehaviorOnNullValues.forValue(
                 getString(OpensearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG)

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchWriter.java
@@ -120,7 +120,8 @@ public class OpensearchWriter {
         private int maxRetry;
         private long retryBackoffMs;
         private boolean dropInvalidMessage;
-        private RecordConverter.BehaviorOnNullValues behaviorOnNullValues = RecordConverter.BehaviorOnNullValues.DEFAULT;
+        private RecordConverter.BehaviorOnNullValues behaviorOnNullValues =
+                RecordConverter.BehaviorOnNullValues.DEFAULT;
         private BulkProcessor.BehaviorOnMalformedDoc behaviorOnMalformedDoc;
 
         public Builder(final OpensearchClient client) {
@@ -283,12 +284,7 @@ public class OpensearchWriter {
         final boolean ignoreSchema) {
 
         try {
-            final IndexableRecord record = converter.convertRecord(
-                sinkRecord,
-                index,
-                type,
-                ignoreKey,
-                ignoreSchema);
+            final IndexableRecord record = converter.convert(sinkRecord, index);
             if (record != null) {
                 bulkProcessor.add(record, flushTimeoutMs);
             }

--- a/src/main/java/io/aiven/kafka/connect/opensearch/RecordConverter.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/RecordConverter.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.data.ConnectSchema;
@@ -53,24 +52,15 @@ public class RecordConverter {
         JSON_CONVERTER.configure(Collections.singletonMap("schemas.enable", "false"), false);
     }
 
-    private final boolean useCompactMapEntries;
-    private final BehaviorOnNullValues behaviorOnNullValues;
+    private final OpensearchSinkConnectorConfig config;
 
-    /**
-     * Create a DataConverter, specifying how map entries with string keys within record
-     * values should be written to JSON. Compact map entries are written as
-     * <code>"entryKey": "entryValue"</code>, while the non-compact form are written as a nested
-     * document such as <code>{"key": "entryKey", "value": "entryValue"}</code>. All map entries
-     * with non-string keys are always written as nested documents.
-     *
-     * @param useCompactMapEntries true for compact map entries with string keys, or false for
-     *                             the nested document form.
-     * @param behaviorOnNullValues behavior for handling records with null values; may not be null
-     */
-    public RecordConverter(final boolean useCompactMapEntries, final BehaviorOnNullValues behaviorOnNullValues) {
-        this.useCompactMapEntries = useCompactMapEntries;
-        this.behaviorOnNullValues =
-            Objects.requireNonNull(behaviorOnNullValues, "behaviorOnNullValues cannot be null.");
+    public RecordConverter(final Boolean useCompactMapEntries,
+                           final RecordConverter.BehaviorOnNullValues behaviorOnNullValues) {
+        this(null);
+    }
+
+    public RecordConverter(final OpensearchSinkConnectorConfig config) {
+        this.config = config;
     }
 
     private String convertKey(final Schema keySchema, final Object key) {
@@ -83,7 +73,7 @@ public class RecordConverter {
             schemaType = ConnectSchema.schemaType(key.getClass());
             if (schemaType == null) {
                 throw new DataException(
-                    String.format("Java class %s does not have corresponding schema type.", key.getClass())
+                        String.format("Java class %s does not have corresponding schema type.", key.getClass())
                 );
             }
         } else {
@@ -102,15 +92,9 @@ public class RecordConverter {
         }
     }
 
-    public IndexableRecord convertRecord(
-        final SinkRecord record,
-        final String index,
-        final String type,
-        final boolean ignoreKey,
-        final boolean ignoreSchema
-    ) {
+    public IndexableRecord convert(final SinkRecord record, final String index) {
         if (record.value() == null) {
-            switch (behaviorOnNullValues) {
+            switch (config.behaviorOnNullValues()) {
                 case IGNORE:
                     return null;
                 case DELETE:
@@ -128,52 +112,47 @@ public class RecordConverter {
                     break;
                 case FAIL:
                     throw new DataException(String.format(
-                        "Sink record with key of %s and null value encountered for topic/partition/offset "
-                            + "%s/%s/%s (to ignore future records like this change the configuration property "
-                            + "'%s' from '%s' to '%s')",
-                        record.key(),
-                        record.topic(),
-                        record.kafkaPartition(),
-                        record.kafkaOffset(),
-                        OpensearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
-                        BehaviorOnNullValues.FAIL,
-                        BehaviorOnNullValues.IGNORE
+                            "Sink record with key of %s and null value encountered for topic/partition/offset "
+                                    + "%s/%s/%s (to ignore future records like this change the configuration property "
+                                    + "'%s' from '%s' to '%s')",
+                            record.key(),
+                            record.topic(),
+                            record.kafkaPartition(),
+                            record.kafkaOffset(),
+                            OpensearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                            BehaviorOnNullValues.FAIL,
+                            BehaviorOnNullValues.IGNORE
                     ));
                 default:
                     throw new RuntimeException(String.format(
-                        "Unknown value for %s enum: %s",
-                        BehaviorOnNullValues.class.getSimpleName(),
-                        behaviorOnNullValues
+                            "Unknown value for %s enum: %s",
+                            BehaviorOnNullValues.class.getSimpleName(),
+                            config.behaviorOnNullValues()
                     ));
             }
         }
 
-        final String id;
-        if (ignoreKey) {
-            id = record.topic()
-                + "+" + record.kafkaPartition()
-                + "+" + record.kafkaOffset();
-        } else {
-            id = convertKey(record.keySchema(), record.key());
-        }
+        final var id = (config.ignoreKeyFor(record.topic()))
+                ? record.topic() + "+" + record.kafkaPartition() + "+" + record.kafkaOffset()
+                : convertKey(record.keySchema(), record.key());
 
-        final String payload = getPayload(record, ignoreSchema);
-        final Long version = ignoreKey ? null : record.kafkaOffset();
-        return new IndexableRecord(new Key(index, type, id), payload, version);
+        final String payload = getPayload(record);
+        final Long version = config.ignoreKeyFor(record.topic()) ? null : record.kafkaOffset();
+        return new IndexableRecord(new Key(index, id), payload, version);
     }
 
-    private String getPayload(final SinkRecord record, final boolean ignoreSchema) {
+    private String getPayload(final SinkRecord record) {
         if (record.value() == null) {
             return null;
         }
 
-        final Schema schema = ignoreSchema
-            ? record.valueSchema()
-            : preProcessSchema(record.valueSchema());
+        final Schema schema = config.ignoreSchemaFor(record.topic())
+                ? record.valueSchema()
+                : preProcessSchema(record.valueSchema());
 
-        final Object value = ignoreSchema
-            ? record.value()
-            : preProcessValue(record.value(), record.valueSchema(), schema);
+        final Object value = config.ignoreSchemaFor(record.topic())
+                ? record.value()
+                : preProcessValue(record.value(), record.valueSchema(), schema);
 
         final byte[] rawJsonPayload = JSON_CONVERTER.fromConnectData(record.topic(), schema, value);
         return new String(rawJsonPayload, StandardCharsets.UTF_8);
@@ -230,14 +209,14 @@ public class RecordConverter {
         final String valueName = valueSchema.name() == null ? valueSchema.type().name() : valueSchema.name();
         final Schema preprocessedKeySchema = preProcessSchema(keySchema);
         final Schema preprocessedValueSchema = preProcessSchema(valueSchema);
-        if (useCompactMapEntries && keySchema.type() == Schema.Type.STRING) {
+        if (config.useCompactMapEntries() && keySchema.type() == Schema.Type.STRING) {
             final SchemaBuilder result = SchemaBuilder.map(preprocessedKeySchema, preprocessedValueSchema);
             return copySchemaBasics(schema, result).build();
         }
         final Schema elementSchema = SchemaBuilder.struct().name(keyName + "-" + valueName)
-            .field(Mapping.KEY_FIELD, preprocessedKeySchema)
-            .field(Mapping.VALUE_FIELD, preprocessedValueSchema)
-            .build();
+                .field(Mapping.KEY_FIELD, preprocessedKeySchema)
+                .field(Mapping.VALUE_FIELD, preprocessedValueSchema)
+                .build();
         return copySchemaBasics(schema, SchemaBuilder.array(elementSchema)).build();
     }
 
@@ -332,12 +311,12 @@ public class RecordConverter {
         final Schema valueSchema = schema.valueSchema();
         final Schema newValueSchema = newSchema.valueSchema();
         final Map<?, ?> map = (Map<?, ?>) value;
-        if (useCompactMapEntries && keySchema.type() == Schema.Type.STRING) {
+        if (config.useCompactMapEntries() && keySchema.type() == Schema.Type.STRING) {
             final Map<Object, Object> processedMap = new HashMap<>();
             for (final Map.Entry<?, ?> entry : map.entrySet()) {
                 processedMap.put(
-                    preProcessValue(entry.getKey(), keySchema, newSchema.keySchema()),
-                    preProcessValue(entry.getValue(), valueSchema, newValueSchema)
+                        preProcessValue(entry.getKey(), keySchema, newSchema.keySchema()),
+                        preProcessValue(entry.getValue(), valueSchema, newValueSchema)
                 );
             }
             return processedMap;
@@ -349,10 +328,10 @@ public class RecordConverter {
             final Schema mapValueSchema = newValueSchema.field(Mapping.VALUE_FIELD).schema();
             mapStruct.put(
                     Mapping.KEY_FIELD,
-                preProcessValue(entry.getKey(), keySchema, mapKeySchema));
+                    preProcessValue(entry.getKey(), keySchema, mapKeySchema));
             mapStruct.put(
                     Mapping.VALUE_FIELD,
-                preProcessValue(entry.getValue(), valueSchema, mapValueSchema));
+                    preProcessValue(entry.getValue(), valueSchema, mapValueSchema));
             mapStructs.add(mapStruct);
         }
         return mapStructs;

--- a/src/test/java/io/aiven/kafka/connect/opensearch/MappingTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/MappingTest.java
@@ -18,6 +18,7 @@
 package io.aiven.kafka.connect.opensearch;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -173,7 +174,13 @@ public class MappingTest {
             }
         }
 
-        final SinkRecordConverter converter = new SinkRecordConverter(true, SinkRecordConverter.BehaviorOnNullValues.IGNORE);
+        final var props = Map.of(
+                OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost",
+                OpensearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                RecordConverter.BehaviorOnNullValues.IGNORE.toString(),
+                OpensearchSinkConnectorConfig.COMPACT_MAP_ENTRIES_CONFIG, "true"
+        );
+        final RecordConverter converter = new RecordConverter(new OpensearchSinkConnectorConfig(props));
         final Schema.Type schemaType = schema.type();
         switch (schemaType) {
             case ARRAY:

--- a/src/test/java/io/aiven/kafka/connect/opensearch/RecordConverterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/RecordConverterTest.java
@@ -39,9 +39,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SinkRecordConverterTest {
+public class RecordConverterTest {
 
-    private SinkRecordConverter converter;
+    private RecordConverter converter;
     private String key;
     private String topic;
     private int partition;
@@ -52,7 +52,7 @@ public class SinkRecordConverterTest {
 
     @BeforeEach
     public void setUp() {
-        converter = new SinkRecordConverter(true, SinkRecordConverter.BehaviorOnNullValues.DEFAULT);
+        converter = createDataConverter(true);
         key = "key";
         topic = "topic";
         partition = 0;
@@ -64,6 +64,21 @@ public class SinkRecordConverterTest {
             .name("struct")
             .field("string", Schema.STRING_SCHEMA)
             .build();
+    }
+
+    private RecordConverter createDataConverter(final boolean useCompactMapEntries) {
+        return createDataConverter(useCompactMapEntries, RecordConverter.BehaviorOnNullValues.DEFAULT);
+    }
+
+    private RecordConverter createDataConverter(final boolean useCompactMapEntries,
+                                                final RecordConverter.BehaviorOnNullValues behaviorOnNullValues) {
+        final var props = Map.of(
+                OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost",
+                OpensearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                behaviorOnNullValues.toString(),
+                OpensearchSinkConnectorConfig.COMPACT_MAP_ENTRIES_CONFIG, Boolean.toString(useCompactMapEntries)
+        );
+        return new RecordConverter(new OpensearchSinkConnectorConfig(props));
     }
 
     @Test
@@ -206,7 +221,7 @@ public class SinkRecordConverterTest {
         final Map<Object, Object> origValue = Map.of("field1", 1, "field2", 2);
 
         // Use the older non-compact format for map entries with string keys
-        converter = new SinkRecordConverter(false, SinkRecordConverter.BehaviorOnNullValues.DEFAULT);
+        converter = createDataConverter(false);
 
         final Schema preProcessedSchema = converter.preProcessSchema(origSchema);
         assertEquals(
@@ -241,7 +256,7 @@ public class SinkRecordConverterTest {
         final Map<Object, Object> origValue = Map.of("field1", 1, "field2", 2);
 
         // Use the newer compact format for map entries with string keys
-        converter = new SinkRecordConverter(true, SinkRecordConverter.BehaviorOnNullValues.DEFAULT);
+        converter = createDataConverter(true);
         final Schema preProcessedSchema = converter.preProcessSchema(origSchema);
         assertEquals(
             SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build(),
@@ -295,7 +310,7 @@ public class SinkRecordConverterTest {
         testOptionalFieldWithoutDefault(SchemaBuilder.struct().field("innerField", Schema.BOOLEAN_SCHEMA));
         testOptionalFieldWithoutDefault(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.BOOLEAN_SCHEMA));
         // Have to test maps with useCompactMapEntries set to true and set to false
-        converter = new SinkRecordConverter(false, SinkRecordConverter.BehaviorOnNullValues.DEFAULT);
+        converter = createDataConverter(false);
         testOptionalFieldWithoutDefault(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.BOOLEAN_SCHEMA));
     }
 
@@ -314,40 +329,40 @@ public class SinkRecordConverterTest {
 
     @Test
     public void ignoreOnNullValue() {
-        converter = new SinkRecordConverter(true, SinkRecordConverter.BehaviorOnNullValues.IGNORE);
+        converter = createDataConverter(true, RecordConverter.BehaviorOnNullValues.IGNORE);
 
         final SinkRecord sinkRecord = createSinkRecordWithValue(null);
-        assertNull(converter.convertRecord(sinkRecord, index, type, false, false));
+        assertNull(converter.convert(sinkRecord, index));
     }
 
     @Test
     public void deleteOnNullValue() {
-        converter = new SinkRecordConverter(true, SinkRecordConverter.BehaviorOnNullValues.DELETE);
+        converter = createDataConverter(true, RecordConverter.BehaviorOnNullValues.DELETE);
 
         final SinkRecord sinkRecord = createSinkRecordWithValue(null);
         final IndexableRecord expectedRecord = createIndexableRecordWithPayload(null);
-        final IndexableRecord actualRecord = converter.convertRecord(sinkRecord, index, type, false, false);
+        final IndexableRecord actualRecord = converter.convert(sinkRecord, index);
 
         assertEquals(expectedRecord, actualRecord);
     }
 
     @Test
     public void ignoreDeleteOnNullValueWithNullKey() {
-        converter = new SinkRecordConverter(true, SinkRecordConverter.BehaviorOnNullValues.DELETE);
+        converter = createDataConverter(true, RecordConverter.BehaviorOnNullValues.DELETE);
         key = null;
 
         final SinkRecord sinkRecord = createSinkRecordWithValue(null);
-        assertNull(converter.convertRecord(sinkRecord, index, type, false, false));
+        assertNull(converter.convert(sinkRecord, index));
     }
 
     @Test
     public void failOnNullValue() {
-        converter = new SinkRecordConverter(true, SinkRecordConverter.BehaviorOnNullValues.FAIL);
+        converter = createDataConverter(true, RecordConverter.BehaviorOnNullValues.FAIL);
 
         final SinkRecord sinkRecord = createSinkRecordWithValue(null);
         assertThrows(
                 DataException.class,
-                () -> converter.convertRecord(sinkRecord, index, type, false, false));
+                () -> converter.convert(sinkRecord, index));
     }
 
     public SinkRecord createSinkRecordWithValue(final Object value) {
@@ -355,7 +370,7 @@ public class SinkRecordConverterTest {
     }
 
     public IndexableRecord createIndexableRecordWithPayload(final String payload) {
-        return new IndexableRecord(new Key(index, type, key), payload, offset);
+        return new IndexableRecord(new Key(index, key), payload, offset);
     }
 
 }


### PR DESCRIPTION
`DataConverter` refactoring:

- Rename `DataConverter` to `RecordConverter`
- The `RecordConverter` class uses the `OpensearchSinkConnectorConfig` one, which is simplify usage of it
