### PR TITLE
Fix capitalization of OpenSearch in all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Aiven's Opensearch Connector for Apache Kafka
+# Aiven's OpenSearch Connector for Apache Kafka
 
 [![Build Status](https://github.com/aiven/opensearch-connector-for-apache-kafka/actions/workflows/master_push_workflow.yml/badge.svg)](https://github.com/aiven/opensearch-connector-for-apache-kafka/actions)
 
-This repository includes Aiven's Opensearch [connector](http://kafka.apache.org/documentation.html#connect) for Apache
+This repository includes Aiven's OpenSearch [connector](http://kafka.apache.org/documentation.html#connect) for Apache
 Kafka.
 
 The project originates from
@@ -11,7 +11,7 @@ The code was forked and all classes were renamed.
 
 # Documentation
 
-[Opensearch Sink Connector Configuration Options](docs/opensearch-sink-connector-config-options.rst)
+[OpenSearch Sink Connector Configuration Options](docs/opensearch-sink-connector-config-options.rst)
 
 # Contribute
 

--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,8 @@ publishing {
             version = getVersion()
 
             pom {
-                name = "Aiven's Opensearch Connector for Apache Kafka"
-                description = "Aiven's Opensearch Connector for Apache Kafka"
+                name = "Aiven's OpenSearch Connector for Apache Kafka"
+                description = "Aiven's OpenSearch Connector for Apache Kafka"
                 url = "https://aiven.io"
                 organization {
                     name = "Aiven Oy"

--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -1,39 +1,39 @@
 =========================================
-Opensearch Sink Connector Configuration Options
+OpenSearch Sink Connector Configuration Options
 =========================================
 
 Connector
 ^^^^^^^^^
 
 ``connection.url``
-  List of Opensearch HTTP connection URLs e.g. ``http://eshost1:9200,http://eshost2:9200``.
+  List of OpenSearch HTTP connection URLs e.g. ``http://eshost1:9200,http://eshost2:9200``.
 
   * Type: list
   * Importance: high
 
 ``connection.username``
-  The username used to authenticate with Opensearch. The default is the null, and authentication will only be performed if  both the username and password are non-null.
+  The username used to authenticate with OpenSearch. The default is the null, and authentication will only be performed if  both the username and password are non-null.
 
   * Type: string
   * Default: null
   * Importance: medium
 
 ``connection.password``
-  The password used to authenticate with Opensearch. The default is the null, and authentication will only be performed if  both the username and password are non-null.
+  The password used to authenticate with OpenSearch. The default is the null, and authentication will only be performed if  both the username and password are non-null.
 
   * Type: password
   * Default: null
   * Importance: medium
 
 ``batch.size``
-  The number of records to process as a batch when writing to Opensearch.
+  The number of records to process as a batch when writing to OpenSearch.
 
   * Type: int
   * Default: 2000
   * Importance: medium
 
 ``max.in.flight.requests``
-  The maximum number of indexing requests that can be in-flight to Opensearch before blocking further requests.
+  The maximum number of indexing requests that can be in-flight to OpenSearch before blocking further requests.
 
   * Type: int
   * Default: 5
@@ -77,14 +77,14 @@ Connector
   * Importance: low
 
 ``connection.timeout.ms``
-  How long to wait in milliseconds when establishing a connection to the Opensearch server. The task fails if the client fails to connect to the server in this interval, and will need to be restarted.
+  How long to wait in milliseconds when establishing a connection to the OpenSearch server. The task fails if the client fails to connect to the server in this interval, and will need to be restarted.
 
   * Type: int
   * Default: 1000
   * Importance: low
 
 ``read.timeout.ms``
-  How long to wait in milliseconds for the Opensearch server to send a response. The task fails if any read operation times out, and will need to be restarted to resume further operations.
+  How long to wait in milliseconds for the OpenSearch server to send a response. The task fails if any read operation times out, and will need to be restarted to resume further operations.
 
   * Type: int
   * Default: 3000
@@ -94,7 +94,7 @@ Data Conversion
 ^^^^^^^^^^^^^^^
 
 ``key.ignore``
-  Whether to ignore the record key for the purpose of forming the Opensearch document ID. When this is set to ``true``, document IDs will be generated as the record's ``topic+partition+offset``.
+  Whether to ignore the record key for the purpose of forming the OpenSearch document ID. When this is set to ``true``, document IDs will be generated as the record's ``topic+partition+offset``.
 
    Note that this is a global config that applies to all topics, use ``topic.key.ignore`` to override as ``true`` for specific topics.
 
@@ -103,7 +103,7 @@ Data Conversion
   * Importance: high
 
 ``schema.ignore``
-  Whether to ignore schemas during indexing. When this is set to ``true``, the record schema will be ignored for the purpose of registering an Opensearch mapping. Opensearch will infer the mapping from the data (dynamic mapping needs to be enabled by the user).
+  Whether to ignore schemas during indexing. When this is set to ``true``, the record schema will be ignored for the purpose of registering an OpenSearch mapping. OpenSearch will infer the mapping from the data (dynamic mapping needs to be enabled by the user).
 
    Note that this is a global config that applies to all topics, use ``topic.schema.ignore`` to override as ``true`` for specific topics.
 
@@ -121,7 +121,7 @@ Data Conversion
 ``topic.index.map``
   This option is now deprecated. A future version may remove it completely. Please use single message transforms, such as RegexRouter, to map topic names to index names.
 
-  A map from Kafka topic name to the destination Opensearch index, represented as a list of ``topic:index`` pairs.
+  A map from Kafka topic name to the destination OpenSearch index, represented as a list of ``topic:index`` pairs.
 
   * Type: list
   * Default: ""
@@ -157,11 +157,9 @@ Data Conversion
   * Importance: low
 
 ``behavior.on.malformed.documents``
-  How to handle records that Opensearch rejects due to some malformation of the document itself, such as an index mapping conflict or a field name containing illegal characters. Valid options are 'ignore', 'warn', and 'fail'.
+  How to handle records that OpenSearch rejects due to some malformation of the document itself, such as an index mapping conflict or a field name containing illegal characters. Valid options are 'ignore', 'warn', and 'fail'.
 
   * Type: string
   * Default: fail
   * Valid Values: [ignore, warn, fail]
   * Importance: low
-
-


### PR DESCRIPTION
Fix capitalization of OpenSearch in all documentation. This does not touch the codebase ie. some classnames.