### PR TITLE
Bump up opensearch version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ publishing {
 ext {
     kafkaVersion = "2.8.1"
     slf4jVersion = "1.7.32"
-    openSearchVersion = "1.0.0"
+    openSearchVersion = "1.2.3"
     luceneVersion = "8.8.2"  // this is the version in OS
 
     testcontainersVersion = "1.16.2"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'aiven-kafka-connect-opensearch'
+rootProject.name = "opensearch-connector-for-apache-kafka"


### PR DESCRIPTION
- Changed root project name from `aiven-kafka-connect-opensearch` to `opensearch-connector-for-apache-kafka`
- Bumped up `Opensearch` version to `1.2.3`