### PR TITLE
Use temurin jdk during build with GitHub Actions

### DIFF
--- a/.github/workflows/main_and_pr_workflow.yml
+++ b/.github/workflows/main_and_pr_workflow.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
The PR makes use of temurin instead of adopt since adopt is deprecated as mentioned at 
https://github.com/actions/setup-java#supported-distributions:

> NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).