### PR TITLE
Remove ElasticsearchSinkConnector message in logs

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnector.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnector.java
@@ -45,7 +45,7 @@ public class OpensearchSinkConnector extends SinkConnector {
             new OpensearchSinkConnectorConfig(props);
         } catch (final ConfigException e) {
             throw new ConnectException(
-                    "Couldn't start ElasticsearchSinkConnector due to configuration error",
+                    "Couldn't start OpensearchSinkConnector due to configuration error",
                     e
             );
         }


### PR DESCRIPTION
Looks like a single reference was missed when converting OS->ES, so lets
fix it up.