### PR TITLE
do not crash with nullpointer

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
@@ -374,20 +374,22 @@ public class BulkProcessor {
                         return response;
                     }
                     for (final var itemResponse : response.getItems()) {
-                        if (!itemResponse.getFailure().isAborted()) {
-                            if (responseContainsMalformedDocError(itemResponse)) {
-                                handleMalformedDoc(itemResponse);
-                            } else if (responseContainsVersionConflict(itemResponse)) {
-                                handleVersionConflict(itemResponse);
+                        if(itemResponse.isFailed()) {
+                            if (!itemResponse.getFailure().isAborted()) {
+                                if (responseContainsMalformedDocError(itemResponse)) {
+                                    handleMalformedDoc(itemResponse);
+                                } else if (responseContainsVersionConflict(itemResponse)) {
+                                    handleVersionConflict(itemResponse);
+                                } else {
+                                    throw new RuntimeException(
+                                            "One of the item in the bulk response failed. Reason: "
+                                            + itemResponse.getFailureMessage());
+                                }
                             } else {
-                                throw new RuntimeException(
-                                        "One of the item in the bulk response failed. Reason: "
-                                            + itemResponse.getFailureMessage());
+                                throw new ConnectException(
+                                        "One of the item in the bulk response aborted. Reason: "
+                                        + itemResponse.getFailureMessage());
                             }
-                        } else {
-                            throw new ConnectException(
-                                    "One of the item in the bulk response aborted. Reason: "
-                                            + itemResponse.getFailureMessage());
                         }
                     }
                     return response;

--- a/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
@@ -374,7 +374,7 @@ public class BulkProcessor {
                         return response;
                     }
                     for (final var itemResponse : response.getItems()) {
-                        if(itemResponse.isFailed()) {
+                        if (itemResponse.isFailed()) {
                             if (!itemResponse.getFailure().isAborted()) {
                                 if (responseContainsMalformedDocError(itemResponse)) {
                                     handleMalformedDoc(itemResponse);


### PR DESCRIPTION
We noticed that when a bulk request fails, it might be that not all items of the bulk request have a failure. In this case a NullPointerException was thrown.