### PR TITLE
Added a default value to the CONNECTION_URL_CONIFG preventing a null pointer exception upon config with full post

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -173,7 +173,7 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
         configDef.define(
                 CONNECTION_URL_CONFIG,
                 Type.LIST,
-                ConfigDef.NO_DEFAULT_VALUE,
+                "https://eshost1:9200",
                 (name, value) -> {
                     @SuppressWarnings("unchecked")
                     final var urls = (List<String>) value;


### PR DESCRIPTION
When configuring the opensearch connector from a ui which uses connect. It automatically retrieves the config's. The opensearch connector at this moment works with a full post message with all the params filled with data. In a UI that is a more interactive proces. Long story short by providing a default value for the CONNECTION_URL_CONFIG the connector will be configurable in a UI who connects to the connector. e.g Kowl 