### PR TITLE
Fix failure on aliases and datastreams

### DIFF
--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchClientIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchClientIT.java
@@ -22,7 +22,10 @@ import java.util.Map;
 
 import org.apache.kafka.connect.data.SchemaBuilder;
 
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.client.RequestOptions;
+import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.client.indices.GetMappingsRequest;
 
 import org.junit.jupiter.api.Test;
@@ -63,6 +66,29 @@ public class OpensearchClientIT extends AbstractIT {
         assertTrue(opensearchClient.createIndex("index_3"));
         assertTrue(opensearchClient.indexExists("index_3"));
         assertFalse(opensearchClient.createIndex("index_3"));
+    }
+
+    @Test
+    void createIndexDoesNotCreateWhenAliasExists() throws Exception {
+        final var config = new OpensearchSinkConnectorConfig(getDefaultProperties());
+        final OpensearchClient tmpClient = new OpensearchClient(config);
+
+        try {
+            tmpClient.client.indices().create(
+                new CreateIndexRequest("index_4").alias(new Alias("alias_1")),
+                RequestOptions.DEFAULT
+            );
+        } catch (final OpenSearchStatusException | IOException e) {
+            throw e;
+        }
+
+        assertFalse(opensearchClient.createIndex("alias_index"));
+    }
+
+    @Test
+    void createIndexDoesNotCreateAlreadyExistingDatastream() {
+        // TODO create datastream "datastream_index"
+        // assertFalse(opensearchClient.createIndex("datastream_index"));
     }
 
     @Test

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchClient.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchClient.java
@@ -64,6 +64,11 @@ public class OpensearchClient implements AutoCloseable {
 
     private static final String RESOURCE_ALREADY_EXISTS_EXCEPTION = "resource_already_exists_exception";
 
+    private static final String RESOURCE_ALREADY_EXISTS_AS_ALIAS = "already exists as alias";
+
+    private static final String RESOURCE_ALREADY_EXISTS_AS_DATASTREAM =
+        "creates data streams only, use create data stream api instead";
+
     private static final String DEFAULT_OS_VERSION = "1.0.0";
 
     private final OpensearchSinkConnectorConfig config;
@@ -121,7 +126,9 @@ public class OpensearchClient implements AutoCloseable {
                         client.indices().create(new CreateIndexRequest(index), RequestOptions.DEFAULT);
                         return true;
                     } catch (final OpenSearchStatusException | IOException e) {
-                        if (!e.getMessage().contains(RESOURCE_ALREADY_EXISTS_EXCEPTION)) {
+                        if (!(e.getMessage().contains(RESOURCE_ALREADY_EXISTS_EXCEPTION)
+                            || e.getMessage().contains(RESOURCE_ALREADY_EXISTS_AS_ALIAS)
+                            || e.getMessage().contains(RESOURCE_ALREADY_EXISTS_AS_DATASTREAM))) {
                             throw e;
                         }
                         return false;

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
@@ -157,8 +157,10 @@ public class OpensearchSinkTask extends SinkTask {
 
     private void ensureIndexExists(final String index) {
         if (!indexCache.contains(index)) {
-            LOGGER.info("Create index {}", index);
-            client.createIndex(index);
+            if (!client.indexExists(index)) {
+                LOGGER.info("Create index {}", index);
+                client.createIndex(index);
+            }
             indexCache.add(index);
         }
     }


### PR DESCRIPTION
There is also some dead code in [OpensearchClient.java](https://github.com/aiven/opensearch-connector-for-apache-kafka/blob/v1.0.1/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchClient.java#L126) which this change causes, but it seems like from [integration tests](https://github.com/aiven/opensearch-connector-for-apache-kafka/blob/6e2bef7dfc645c3d8728a2c15c25ea0acf303b7d/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchClientIT.java#L62) it seems it should stay idempotent.

Basically indexes, aliases, and datastreams all return true on
```
client.indices().exists(new GetIndexRequest(index), RequestOptions.DEFAULT);
```

So checking beforehand and not trying to create an index should solve the exception raised in #85.
A caveat for datastreams: a datastream is not recognized as an index with an index template alone, it requires the datastream to be intialized via `PUT _data_stream/the-datastream`.