### PR TITLE
Fix NullPointerException for connection.url config property

### DIFF
--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorIT.java
@@ -125,6 +125,17 @@ public class OpensearchSinkConnectorIT extends AbstractIT {
         }
     }
 
+    @Test
+    public void testConnectorConfig() throws Exception {
+        assertNotNull(
+                connect.validateConnectorConfig(
+                        "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector",
+                        Map.of("connector.class", "io.aiven.kafka.connect.opensearch.OpensearchSinkConnector",
+                                "topics", "example-topic-name")
+                )
+        );
+    }
+
     void writeRecords(final int numRecords) {
         for (int i = 0; i < numRecords; i++) {
             connect.kafka().produce(

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -19,6 +19,7 @@ package io.aiven.kafka.connect.opensearch;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -173,7 +174,7 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
         configDef.define(
                 CONNECTION_URL_CONFIG,
                 Type.LIST,
-                ConfigDef.NO_DEFAULT_VALUE,
+                new ArrayList<>(),
                 (name, value) -> {
                     @SuppressWarnings("unchecked")
                     final var urls = (List<String>) value;


### PR DESCRIPTION
Fixed `NullPointerException` for `connection.url` config property.

Since `connection.url` definition did not use default vaue. Connector configuration validation could failed with NullPointerException if `connection.url` has not been set.