### PR TITLE
Provide the SPI to contribute custom property definitions to connector's configuration

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/opensearch/spi/ConfigDefContributor.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/spi/ConfigDefContributor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch.spi;
+
+import java.util.ServiceLoader;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+/**
+ * Allow to enrich the connector's configuration with custom configuration definitions 
+ * using {@link ServiceLoader} mechanism to discover them.
+ */
+public interface ConfigDefContributor {
+    /**
+     * Contribute custom configuration definitions to the connector's configuration.
+     * @param config connector's configuration.
+     */
+    void addConfig(final ConfigDef config);
+}

--- a/src/test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfigTest.java
@@ -20,7 +20,13 @@ package io.aiven.kafka.connect.opensearch;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigException;
+
+import io.aiven.kafka.connect.opensearch.spi.ConfigDefContributor;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,5 +67,43 @@ public class OpensearchSinkConnectorConfigTest {
     public void testThrowsConfigExceptionForWrongUrls() {
         props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "ttp://asdsad");
         assertThrows(ConfigException.class, () -> new OpensearchSinkConnectorConfig(props));
+    }
+
+    @Test
+    public void testAddConfigDefs() {
+        props.put("custom.property.1", "10");
+        props.put("custom.property.2", "http://localhost:9000");
+        final OpensearchSinkConnectorConfig config = new OpensearchSinkConnectorConfig(props);
+        assertEquals(config.getInt("custom.property.1"), 10);
+        assertEquals(config.getString("custom.property.2"), "http://localhost:9000");
+    }
+    
+    public static class CustomConfigDefContributor implements ConfigDefContributor {
+        @Override
+        public void addConfig(final ConfigDef config) {
+            config
+                .define(
+                    "custom.property.1",
+                    Type.INT,
+                    null,
+                    Importance.MEDIUM,
+                    "Custom string property 1 description",
+                    "custom",
+                    0,
+                    Width.SHORT,
+                    "Custom string property 1"
+                )
+                .define(
+                    "custom.property.2",
+                    Type.STRING,
+                    null,
+                    Importance.MEDIUM,
+                    "Custom string property 2 description",
+                    "custom",
+                    1,
+                    Width.SHORT,
+                    "Custom string property 2"
+                );
+        }
     }
 }

--- a/src/test/resources/META-INF/services/io.aiven.kafka.connect.opensearch.spi.ConfigDefContributor
+++ b/src/test/resources/META-INF/services/io.aiven.kafka.connect.opensearch.spi.ConfigDefContributor
@@ -1,0 +1,1 @@
+io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfigTest$CustomConfigDefContributor


### PR DESCRIPTION
The suggested SPI allows to dynamically discover available configuration definition contributors and enrich connector's configuration based on that. Closes https://github.com/aiven/opensearch-connector-for-apache-kafka/issues/130