### PR TITLE
Dead letter queue support

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -289,7 +289,8 @@
 
         <!-- See http://checkstyle.sourceforge.net/config_metrics.html#ClassFanOutComplexity -->
         <module name="ClassFanOutComplexity">
-            <property name="max" value="21"/>
+            <property name="max" value="23"/>
+            <property name="excludedPackages" value="java.io,java.util,org.slf4j"/>
         </module>
 
         <!-- See http://checkstyle.sourceforge.net/config_metrics.html#CyclomaticComplexity -->

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskIT.java
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.apache.kafka.test.TestUtils;
 
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -50,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class OpensearchSinkTaskIT extends AbstractIT {
 
@@ -133,6 +135,8 @@ public class OpensearchSinkTaskIT extends AbstractIT {
 
         final var opensearchSinkTask = new OpensearchSinkTask();
         try {
+            final var mockContext = mock(SinkTaskContext.class);
+            opensearchSinkTask.initialize(mockContext);
             opensearchSinkTask.start(getDefaultTaskProperties(true, RecordConverter.BehaviorOnNullValues.DEFAULT));
             opensearchSinkTask.put(
                     List.of(
@@ -363,6 +367,8 @@ public class OpensearchSinkTaskIT extends AbstractIT {
 
     private void runTask(final Map<String, String> props, final List<SinkRecord> records) {
         final var opensearchSinkTask = new OpensearchSinkTask();
+        final var mockContext = mock(SinkTaskContext.class);
+        opensearchSinkTask.initialize(mockContext);
         try {
             opensearchSinkTask.start(props);
             opensearchSinkTask.put(records);

--- a/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
@@ -32,10 +32,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
 
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.bulk.BulkItemResponse;
@@ -77,12 +80,21 @@ public class BulkProcessor {
 
     // shared state, synchronized on (this), may be part of wait() conditions so need notifyAll() on
     // changes
-    private final Deque<DocWriteRequest<?>> unsentRecords;
+    private final Deque<DocWriteWrapper> unsentRecords;
     private int inFlightRecords = 0;
+
+    private final ErrantRecordReporter reporter;
 
     public BulkProcessor(final Time time,
                          final RestHighLevelClient client,
                          final OpensearchSinkConnectorConfig config) {
+        this(time, client, config, null);
+    }
+
+    public BulkProcessor(final Time time,
+                         final RestHighLevelClient client,
+                         final OpensearchSinkConnectorConfig config,
+                         final ErrantRecordReporter reporter) {
         this.time = time;
         this.client = client;
 
@@ -93,13 +105,14 @@ public class BulkProcessor {
         this.retryBackoffMs = config.retryBackoffMs();
         this.behaviorOnMalformedDoc = config.behaviorOnMalformedDoc();
         this.behaviorOnVersionConflict = config.behaviorOnVersionConflict();
+        this.reporter = reporter;
 
         unsentRecords = new ArrayDeque<>(maxBufferedRecords);
 
         final ThreadFactory threadFactory = makeThreadFactory();
         farmer = threadFactory.newThread(farmerTask());
         executor = Executors.newFixedThreadPool(config.maxInFlightRequests(), threadFactory);
-        
+
         if (!config.ignoreKey() && config.behaviorOnVersionConflict() == BehaviorOnVersionConflict.FAIL) {
             LOGGER.warn("The {} is set to `false` which assumes external version and optimistic locking."
                     + " You may consider changing the configuration property '{}' from '{}' to '{}' or '{}'"
@@ -162,7 +175,7 @@ public class BulkProcessor {
     private synchronized Future<BulkResponse> submitBatch() {
         assert !unsentRecords.isEmpty();
         final int batchableSize = Math.min(batchSize, unsentRecords.size());
-        final var batch = new ArrayList<DocWriteRequest<?>>(batchableSize);
+        final var batch = new ArrayList<DocWriteWrapper>(batchableSize);
         for (int i = 0; i < batchableSize; i++) {
             batch.add(unsentRecords.removeFirst());
         }
@@ -279,7 +292,8 @@ public class BulkProcessor {
      * <p>If any task has failed prior to or while blocked in the add, or if the timeout expires
      * while blocked, {@link ConnectException} will be thrown.
      */
-    public synchronized void add(final DocWriteRequest<?> request, final long timeoutMs) {
+    public synchronized void add(final DocWriteRequest<?> docWriteRequests, final SinkRecord sinkRecord,
+                                 final long timeoutMs) {
         throwIfTerminal();
 
         if (bufferedRecords() >= maxBufferedRecords) {
@@ -299,7 +313,7 @@ public class BulkProcessor {
             }
         }
 
-        unsentRecords.addLast(request);
+        unsentRecords.addLast(new DocWriteWrapper(docWriteRequests, sinkRecord));
         notifyAll();
     }
 
@@ -338,13 +352,13 @@ public class BulkProcessor {
 
         final long batchId = BATCH_ID_GEN.incrementAndGet();
 
-        final List<DocWriteRequest<?>> batch;
+        final List<DocWriteWrapper> batch;
 
         final int maxRetries;
 
         final long retryBackoffMs;
 
-        BulkTask(final List<DocWriteRequest<?>> batch, final int maxRetries, final long retryBackoffMs) {
+        BulkTask(final List<DocWriteWrapper> batch, final int maxRetries, final long retryBackoffMs) {
             this.batch = batch;
             this.maxRetries = maxRetries;
             this.retryBackoffMs = retryBackoffMs;
@@ -363,11 +377,19 @@ public class BulkProcessor {
             }
         }
 
+        private void sendToErrantRecordReporter(final String errorMessage, final SinkRecord batchRecord) {
+            LOGGER.debug(errorMessage);
+            reporter.report(batchRecord, new Exception(errorMessage));
+        }
+
         private BulkResponse execute() throws Exception {
             return callWithRetry("bulk processing", () -> {
                 try {
                     final var response =
-                            client.bulk(new BulkRequest().add(batch), RequestOptions.DEFAULT);
+                            client.bulk(new BulkRequest().add(
+                                            batch.stream().map(DocWriteWrapper::getDocWriteRequest)
+                                                    .collect(Collectors.toList())),
+                                    RequestOptions.DEFAULT);
                     if (!response.hasFailures()) {
                         // We only logged failures, so log the success immediately after a failure ...
                         LOGGER.debug("Completed batch {} of {} records", batchId, batch.size());
@@ -410,6 +432,16 @@ public class BulkProcessor {
                                     + " records. Ignoring and will keep an existing record. Error was {}",
                             batchId, batch.size(), bulkItemResponse.getFailureMessage());
                     break;
+                case REPORT:
+                    final String errorMessage =
+                            String.format("Encountered a version conflict when executing batch %s of %s"
+                                            + " records. Reporting this error to the errant record reporter and will"
+                                            + " keep an existing record."
+                                            + " Rest status: %s, Action id: %s, Error message: %s",
+                                    batchId, batch.size(), bulkItemResponse.getFailure().getStatus(),
+                                    bulkItemResponse.getFailure().getId(), bulkItemResponse.getFailureMessage());
+                    sendToErrantRecordReporter(errorMessage, batch.get(bulkItemResponse.getItemId()).getSinkRecord());
+                    break;
                 case WARN:
                     LOGGER.warn("Encountered a version conflict when executing batch {} of {}"
                                     + " records. Ignoring and will keep an existing record. Error was {}",
@@ -439,6 +471,16 @@ public class BulkProcessor {
                                     + " records. Ignoring and will not index record. Error was {}",
                             batchId, batch.size(), bulkItemResponse.getFailureMessage());
                     break;
+                case REPORT:
+                    final String errorMessage =
+                            String.format("Encountered a version conflict when executing batch %s of %s"
+                                            + " records. Reporting this error to the errant record reporter"
+                                            + " and will not index record."
+                                            + " Rest status: %s, Action id: %s, Error message: %s",
+                                    batchId, batch.size(), bulkItemResponse.getFailure().getStatus(),
+                                    bulkItemResponse.getFailure().getId(), bulkItemResponse.getFailureMessage());
+                    sendToErrantRecordReporter(errorMessage, batch.get(bulkItemResponse.getItemId()).getSinkRecord());
+                    break;
                 case WARN:
                     LOGGER.warn("Encountered an illegal document error when executing batch {} of {}"
                                     + " records. Ignoring and will not index record. Error was {}",
@@ -457,7 +499,27 @@ public class BulkProcessor {
             }
         }
     }
-    
+
+    private static final class DocWriteWrapper {
+
+        private final DocWriteRequest<?> docWriteRequest;
+        private final SinkRecord sinkRecord;
+
+        DocWriteWrapper(final DocWriteRequest<?> docWriteRequests, final SinkRecord sinkRecord) {
+            this.docWriteRequest = docWriteRequests;
+            this.sinkRecord = sinkRecord;
+        }
+
+        public DocWriteRequest<?> getDocWriteRequest() {
+            return docWriteRequest;
+        }
+
+        public SinkRecord getSinkRecord() {
+            return sinkRecord;
+        }
+    }
+
+
     private boolean responseContainsVersionConflict(final BulkItemResponse bulkItemResponse) {
         return bulkItemResponse.getFailure().getStatus() == RestStatus.CONFLICT
                 || bulkItemResponse.getFailureMessage().contains("version_conflict_engine_exception");
@@ -499,7 +561,8 @@ public class BulkProcessor {
     public enum BehaviorOnMalformedDoc {
         IGNORE,
         WARN,
-        FAIL;
+        FAIL,
+        REPORT;
 
         public static final BehaviorOnMalformedDoc DEFAULT = FAIL;
 
@@ -545,11 +608,12 @@ public class BulkProcessor {
             return name().toLowerCase(Locale.ROOT);
         }
     }
-    
+
     public enum BehaviorOnVersionConflict {
         IGNORE,
         WARN,
-        FAIL;
+        FAIL,
+        REPORT;
 
         public static final BehaviorOnVersionConflict DEFAULT = FAIL;
 

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -157,13 +157,16 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
     private static final String BEHAVIOR_ON_MALFORMED_DOCS_DOC = "How to handle records that "
             + "OpenSearch rejects due to some malformation of the document itself, such as an index"
             + " mapping conflict or a field name containing illegal characters. Valid options are "
-            + "``ignore``, ``warn``, and ``fail``.";
+            + "``ignore`` - do not index the record, ``warn`` - log a warning message and do not index the record, "
+            + "``report`` - report to errant record reporter and do not index the record, ``fail`` - fail the task.";
     
     public static final String BEHAVIOR_ON_VERSION_CONFLICT_CONFIG = "behavior.on.version.conflict";
     private static final String BEHAVIOR_ON_VERSION_CONFLICT_DOC = "How to handle records that "
             + "OpenSearch rejects due to document's version conflicts. It may happen when offsets "
             + "were not committed or/and records have to be reprocessed. "
-            + "Valid options are ``ignore``, ``warn``, and ``fail``.";
+            + "Valid options are ``ignore`` - ignore and keep the existing record, "
+            + "``warn`` - log a warning message and keep the existing record, "
+            + "``report`` - report to errant record reporter and keep the existing record, ``fail`` - fail the task.";
 
     public static final String INDEX_WRITE_METHOD = "index.write.method";
 
@@ -507,6 +510,11 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
     public OpensearchSinkConnectorConfig(final Map<String, String> props) {
         super(CONFIG, props);
         validate();
+    }
+
+    public boolean requiresErrantRecordReporter() {
+        return behaviorOnMalformedDoc() == BulkProcessor.BehaviorOnMalformedDoc.REPORT
+                || behaviorOnVersionConflict() == BulkProcessor.BehaviorOnVersionConflict.REPORT;
     }
 
     private void validate() {

--- a/src/test/java/io/aiven/kafka/connect/opensearch/BulkProcessorTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/BulkProcessorTest.java
@@ -18,15 +18,20 @@
 package io.aiven.kafka.connect.opensearch;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
 
 import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.bulk.BulkRequest;
@@ -63,6 +68,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -140,18 +146,18 @@ public class BulkProcessorTest {
         final var bulkProcessor = new BulkProcessor(Time.SYSTEM, client, config);
 
         final int addTimeoutMs = 10;
-        bulkProcessor.add(newIndexRequest(1), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(2), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(3), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(4), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(5), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(6), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(7), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(8), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(9), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(10), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(11), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(12), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(1), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(2), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(3), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(4), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(5), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(6), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(7), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(8), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(9), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(10), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(11), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(12), newSinkRecord(), addTimeoutMs);
 
         clientAnswer.expect(
                 List.of(
@@ -211,9 +217,9 @@ public class BulkProcessorTest {
         bulkProcessor.start();
 
         final int addTimeoutMs = 10;
-        bulkProcessor.add(newIndexRequest(1), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(2), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(3), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(1), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(2), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(3), newSinkRecord(), addTimeoutMs);
 
         assertFalse(clientAnswer.expectationsMet());
 
@@ -239,9 +245,10 @@ public class BulkProcessorTest {
         final var bulkProcessor = new BulkProcessor(Time.SYSTEM, client, config);
 
         final int addTimeoutMs = 10;
-        bulkProcessor.add(newIndexRequest(42), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(42), newSinkRecord(), addTimeoutMs);
         assertEquals(1, bulkProcessor.bufferedRecords());
-        assertThrows(ConnectException.class, () -> bulkProcessor.add(newIndexRequest(43), addTimeoutMs));
+        assertThrows(ConnectException.class,
+                () -> bulkProcessor.add(newIndexRequest(43), newSinkRecord(), addTimeoutMs));
     }
 
     @Test
@@ -267,8 +274,8 @@ public class BulkProcessorTest {
         clientAnswer.expect(List.of(newIndexRequest(42), newIndexRequest(43)), successResponse());
 
         final int addTimeoutMs = 10;
-        bulkProcessor.add(newIndexRequest(42), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(43), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(42), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(43), newSinkRecord(), addTimeoutMs);
 
         assertFalse(bulkProcessor.submitBatchWhenReady().get().hasFailures());
 
@@ -298,8 +305,8 @@ public class BulkProcessorTest {
         clientAnswer.expect(List.of(newIndexRequest(42), newIndexRequest(43)), failedResponse());
 
         final int addTimeoutMs = 10;
-        bulkProcessor.add(newIndexRequest(42), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(43), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(42), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(43), newSinkRecord(), addTimeoutMs);
 
         assertThrows(ExecutionException.class, () -> bulkProcessor.submitBatchWhenReady().get());
         verify(client, times(3)).bulk(any(BulkRequest.class), eq(RequestOptions.DEFAULT));
@@ -328,8 +335,8 @@ public class BulkProcessorTest {
         );
 
         final int addTimeoutMs = 10;
-        bulkProcessor.add(newIndexRequest(42), addTimeoutMs);
-        bulkProcessor.add(newIndexRequest(43), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(42), newSinkRecord(), addTimeoutMs);
+        bulkProcessor.add(newIndexRequest(43), newSinkRecord(), addTimeoutMs);
 
         assertThrows(ExecutionException.class, () -> bulkProcessor.submitBatchWhenReady().get());
         verify(client, times(1)).bulk(any(BulkRequest.class), eq(RequestOptions.DEFAULT));
@@ -367,8 +374,8 @@ public class BulkProcessorTest {
 
         bulkProcessor.start();
 
-        bulkProcessor.add(newIndexRequest(42), 1);
-        bulkProcessor.add(newIndexRequest(43), 1);
+        bulkProcessor.add(newIndexRequest(42), newSinkRecord(), 1);
+        bulkProcessor.add(newIndexRequest(43), newSinkRecord(), 1);
 
         assertThrows(ConnectException.class, () -> bulkProcessor.flush(1000));
         verify(client, times(1)).bulk(any(BulkRequest.class), eq(RequestOptions.DEFAULT));
@@ -412,8 +419,8 @@ public class BulkProcessorTest {
 
             bulkProcessor.start();
 
-            bulkProcessor.add(newIndexRequest(42), 1);
-            bulkProcessor.add(newIndexRequest(43), 1);
+            bulkProcessor.add(newIndexRequest(42), newSinkRecord(), 1);
+            bulkProcessor.add(newIndexRequest(43), newSinkRecord(), 1);
 
             final int flushTimeoutMs = 1000;
             bulkProcessor.flush(flushTimeoutMs);
@@ -450,8 +457,8 @@ public class BulkProcessorTest {
 
         bulkProcessor.start();
 
-        bulkProcessor.add(newIndexRequest(42), 1);
-        bulkProcessor.add(newIndexRequest(43), 1);
+        bulkProcessor.add(newIndexRequest(42), newSinkRecord(), 1);
+        bulkProcessor.add(newIndexRequest(43), newSinkRecord(), 1);
 
         assertThrows(ConnectException.class, () -> bulkProcessor.flush(1000));
         verify(client, times(1)).bulk(any(BulkRequest.class), eq(RequestOptions.DEFAULT));
@@ -486,11 +493,130 @@ public class BulkProcessorTest {
 
         bulkProcessor.start();
 
-        bulkProcessor.add(newIndexRequest(42), 1);
-        bulkProcessor.add(newIndexRequest(43), 1);
+        bulkProcessor.add(newIndexRequest(42), newSinkRecord(), 1);
+        bulkProcessor.add(newIndexRequest(43), newSinkRecord(), 1);
         bulkProcessor.flush(1000);
 
         assertTrue(clientAnswer.expectationsMet());
+    }
+
+    @Test
+    public void reportToDlqWhenVersionConflictBehaviorIsReport(final @Mock RestHighLevelClient client)
+            throws IOException {
+        final var clientAnswer = new ClientAnswer();
+        when(client.bulk(any(BulkRequest.class), eq(RequestOptions.DEFAULT))).thenAnswer(clientAnswer);
+
+        final var dlqReporter = mock(ErrantRecordReporter.class);
+        final var config = new OpensearchSinkConnectorConfig(Map.of(
+                CONNECTION_URL_CONFIG, "http://localhost",
+                MAX_BUFFERED_RECORDS_CONFIG, "100",
+                MAX_IN_FLIGHT_REQUESTS_CONFIG, "5",
+                BATCH_SIZE_CONFIG, "2",
+                BEHAVIOR_ON_VERSION_CONFLICT_CONFIG, BehaviorOnMalformedDoc.REPORT.toString()
+        ));
+
+        final String errorInfo =
+                " [{\"type\":\"version_conflict_engine_exception\","
+                        + "\"reason\":\"[1]: version conflict, current version [3] is higher or"
+                        + " equal to the one provided [3]\""
+                        + "}]";
+
+        final var bulkProcessor = new BulkProcessor(Time.SYSTEM, client, config, dlqReporter);
+        clientAnswer.expect(
+                List.of(
+                        newIndexRequest(111)
+                ), failedResponse(errorInfo, false));
+
+        bulkProcessor.start();
+
+        bulkProcessor.add(newIndexRequest(111), newSinkRecord(), 1);
+
+        final int flushTimeoutMs = 1000;
+        bulkProcessor.flush(flushTimeoutMs);
+
+        assertTrue(clientAnswer.expectationsMet());
+        verify(dlqReporter, times(1)).report(any(SinkRecord.class), any(Throwable.class));
+    }
+
+    @Test
+    public void reportToDlqWhenMalformedDocBehaviorIsReport(final @Mock RestHighLevelClient client) throws IOException {
+        final var clientAnswer = new ClientAnswer();
+        when(client.bulk(any(BulkRequest.class), eq(RequestOptions.DEFAULT))).thenAnswer(clientAnswer);
+
+        final var dlqReporter = mock(ErrantRecordReporter.class);
+        final var config = new OpensearchSinkConnectorConfig(Map.of(
+                CONNECTION_URL_CONFIG, "http://localhost",
+                MAX_BUFFERED_RECORDS_CONFIG, "100",
+                MAX_IN_FLIGHT_REQUESTS_CONFIG, "5",
+                BATCH_SIZE_CONFIG, "2",
+                BEHAVIOR_ON_MALFORMED_DOCS_CONFIG, BehaviorOnMalformedDoc.REPORT.toString()
+        ));
+        final String errorInfo =
+                " [{\"type\":\"mapper_parsing_exception\",\"reason\":\"failed to parse\","
+                        + "\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"object\n"
+                        + " field starting or ending with a [.] "
+                        + "makes object resolution ambiguous: [avjpz{{.}}wjzse{{..}}gal9d]\"}}]";
+        final var bulkProcessor = new BulkProcessor(Time.SYSTEM, client, config, dlqReporter);
+        clientAnswer.expect(
+                List.of(
+                        newIndexRequest(111)
+                 ), failedResponse(errorInfo, false));
+
+        bulkProcessor.start();
+
+        bulkProcessor.add(newIndexRequest(111), newSinkRecord(), 1);
+
+        final int flushTimeoutMs = 1000;
+        bulkProcessor.flush(flushTimeoutMs);
+
+        assertTrue(clientAnswer.expectationsMet());
+        verify(dlqReporter, times(1)).report(any(SinkRecord.class), any(Throwable.class));
+    }
+
+    @Test
+    public void doNotReportToDlqWhenReportIsNotConfigured(final @Mock RestHighLevelClient client)
+            throws IOException {
+        final var clientAnswer = new ClientAnswer();
+        when(client.bulk(any(BulkRequest.class), eq(RequestOptions.DEFAULT))).thenAnswer(clientAnswer);
+
+        final var dlqReporter = mock(ErrantRecordReporter.class);
+        final var config = new OpensearchSinkConnectorConfig(Map.of(
+                CONNECTION_URL_CONFIG, "http://localhost",
+                MAX_BUFFERED_RECORDS_CONFIG, "100",
+                MAX_IN_FLIGHT_REQUESTS_CONFIG, "5",
+                BATCH_SIZE_CONFIG, "2",
+                LINGER_MS_CONFIG, "1000",
+                MAX_RETRIES_CONFIG, "3",
+                READ_TIMEOUT_MS_CONFIG, "1",
+                BEHAVIOR_ON_MALFORMED_DOCS_CONFIG, BehaviorOnMalformedDoc.WARN.toString()
+        ));
+        final String errorInfo =
+                " [{\"type\":\"mapper_parsing_exception\",\"reason\":\"failed to parse\","
+                        + "\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"object\n"
+                        + " field starting or ending with a [.] "
+                        + "makes object resolution ambiguous: [avjpz{{.}}wjzse{{..}}gal9d]\"}}]";
+        final var bulkProcessor = new BulkProcessor(Time.SYSTEM, client, config, dlqReporter);
+        clientAnswer.expect(
+                List.of(
+                        newIndexRequest(222)
+                 ), failedResponse(errorInfo, false));
+
+        bulkProcessor.start();
+
+        bulkProcessor.add(newIndexRequest(222), newSinkRecord(), 1);
+
+        final int flushTimeoutMs = 1000;
+        bulkProcessor.flush(flushTimeoutMs);
+
+        assertTrue(clientAnswer.expectationsMet());
+        verify(dlqReporter, never()).report(any(SinkRecord.class), any(Throwable.class));
+    }
+
+    private SinkRecord newSinkRecord() {
+        final Map<String, Object> valueMap = new HashMap<>();
+        valueMap.put("test_field", ThreadLocalRandom.current().nextInt());
+        return new SinkRecord("test_topic", 0, Schema.STRING_SCHEMA,
+                ThreadLocalRandom.current().nextLong(), null, valueMap, ThreadLocalRandom.current().nextInt());
     }
 
     IndexRequest newIndexRequest(final int body) {

--- a/src/test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.Map;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.BEHAVIOR_ON_VERSION_CONFLICT_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.LINGER_MS_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.MAX_RETRIES_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class OpensearchSinkTaskTest {
+
+    @Test
+    void failToStartWhenReportIsConfiguredAndErrantRecordReporterIsMissing(final @Mock SinkTaskContext context) {
+
+        final var props = Map.of(
+                CONNECTION_URL_CONFIG, "http://localhost",
+                MAX_BUFFERED_RECORDS_CONFIG, "100",
+                MAX_IN_FLIGHT_REQUESTS_CONFIG, "5",
+                BATCH_SIZE_CONFIG, "2",
+                LINGER_MS_CONFIG, "1000",
+                MAX_RETRIES_CONFIG, "3",
+                READ_TIMEOUT_MS_CONFIG, "1",
+                BEHAVIOR_ON_VERSION_CONFLICT_CONFIG, BulkProcessor.BehaviorOnMalformedDoc.REPORT.toString()
+        );
+        when(context.errantRecordReporter()).thenReturn(null);
+        final var task = new OpensearchSinkTask();
+        task.initialize(context);
+        final Exception exception = assertThrows(ConnectException.class, () -> task.start(props));
+        assertTrue(exception.getCause().getMessage().contains("Errant record reporter must be configured"));
+    }
+
+    @Test
+    void failToStartWhenReportIsConfiguredAndErrantRecordReporterIsNotSupported(final @Mock SinkTaskContext context) {
+
+        final var props = Map.of(
+                CONNECTION_URL_CONFIG, "http://localhost",
+                MAX_BUFFERED_RECORDS_CONFIG, "100",
+                MAX_IN_FLIGHT_REQUESTS_CONFIG, "5",
+                BATCH_SIZE_CONFIG, "2",
+                LINGER_MS_CONFIG, "1000",
+                MAX_RETRIES_CONFIG, "3",
+                READ_TIMEOUT_MS_CONFIG, "1",
+                BEHAVIOR_ON_VERSION_CONFLICT_CONFIG, BulkProcessor.BehaviorOnMalformedDoc.REPORT.toString()
+        );
+        when(context.errantRecordReporter()).thenThrow(new NoSuchMethodError());
+        final var task = new OpensearchSinkTask();
+        task.initialize(context);
+        final Exception exception = assertThrows(ConnectException.class, () -> task.start(props));
+        assertTrue(exception.getCause().getMessage().contains("Errant record reporter must be configured"));
+    }
+}


### PR DESCRIPTION
When DLQ is configured, move malformed records (ones that fail to be indexed in OpenSearch due to mapping issues) to the DLQ topic.
Records moved to DLQ will be added with a header named "__connect.errors.exception.message", containing the reason for the failure (the error message as reported by OpenSearch).
