### PR TITLE
Add Data Stream support

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -25,7 +25,7 @@
     />
 
     <suppress
-            checks="(ClassFanOutComplexity)" files="(JestOpensearchClient|JestOpensearchClientTest).java"
+            checks="(ClassFanOutComplexity)" files="(OpensearchClient).java"
     />
 
 </suppressions>

--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -9,7 +9,7 @@ Connector
   List of OpenSearch HTTP connection URLs e.g. ``http://eshost1:9200,http://eshost2:9200``.
 
   * Type: list
-  * Default: ""
+  * Valid Values: http://eshost1:9200, http://eshost2:9200
   * Importance: high
 
 ``batch.size``
@@ -17,6 +17,13 @@ Connector
 
   * Type: int
   * Default: 2000
+  * Importance: medium
+
+``max.in.flight.requests``
+  The maximum number of indexing requests that can be in-flight to OpenSearch before blocking further requests.
+
+  * Type: int
+  * Default: 5
   * Importance: medium
 
 ``max.buffered.records``
@@ -34,13 +41,6 @@ Connector
   * Type: long
   * Default: 1
   * Importance: low
-
-``max.in.flight.requests``
-  The maximum number of indexing requests that can be in-flight to OpenSearch before blocking further requests.
-
-  * Type: int
-  * Default: 5
-  * Importance: medium
 
 ``flush.timeout.ms``
   The timeout in milliseconds to use for periodic flushing, and when waiting for buffer space to be made available by completed requests as records are added. If this timeout is exceeded the task will fail.
@@ -113,15 +113,6 @@ Data Conversion
   * Default: true
   * Importance: low
 
-``topic.index.map``
-  This option is now deprecated. A future version may remove it completely. Please use single message transforms, such as RegexRouter, to map topic names to index names.
-
-  A map from Kafka topic name to the destination OpenSearch index, represented as a list of ``topic:index`` pairs.
-
-  * Type: list
-  * Default: ""
-  * Importance: low
-
 ``topic.key.ignore``
   List of topics for which ``key.ignore`` should be ``true``.
 
@@ -166,6 +157,32 @@ Data Conversion
   * Default: fail
   * Valid Values: [ignore, warn, fail]
   * Importance: low
+
+Data Stream
+^^^^^^^^^^^
+
+``data.stream.enabled``
+  Enable use of data streams. If set to true the connector will write to data streams instead of regular indices. Default is false.
+
+  * Type: boolean
+  * Default: false
+  * Importance: medium
+
+``data.stream.prefix``
+  Generic data stream name to write into. If set, it will be used to construct the final data stream name in the form of {data.stream.prefix}-{topic}.
+
+  * Type: string
+  * Default: null
+  * Valid Values: non-empty string
+  * Importance: medium
+
+``data.stream.timestamp.field``
+  The Kafka record field to use as the timestamp for the @timestamp field in documents sent to a data stream. The default is @timestamp.
+
+  * Type: string
+  * Default: @timestamp
+  * Valid Values: non-empty string
+  * Importance: medium
 
 Authentication
 ^^^^^^^^^^^^^^

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.runtime.AbstractStatus;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.SCHEMA_IGNORE_CONFIG;
+import static org.apache.kafka.connect.json.JsonConverterConfig.SCHEMAS_ENABLE_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
+
+
+public class AbstractKafkaConnectIT extends AbstractIT {
+
+    static final Logger LOGGER = LoggerFactory.getLogger(AbstractKafkaConnectIT.class);
+
+    static final long CONNECTOR_STARTUP_DURATION_MS = TimeUnit.MINUTES.toMillis(60);
+
+    EmbeddedConnectCluster connect;
+
+    final String topicName;
+
+    final String connectorName;
+
+    protected AbstractKafkaConnectIT(final String topicName, final String connectorName) {
+        this.topicName = topicName;
+        this.connectorName = connectorName;
+    }
+
+    @BeforeEach
+    void startConnect() {
+        connect = new EmbeddedConnectCluster.Builder()
+                .name("elasticsearch-it-connect-cluster")
+                .build();
+        connect.start();
+        connect.kafka().createTopic(topicName);
+    }
+
+    @AfterEach
+    void stopConnect() {
+        try (final var admin = connect.kafka().createAdminClient()) {
+            final var result = admin.deleteTopics(List.of(topicName));
+            result.all().get();
+        } catch (final ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        connect.stop();
+    }
+
+    long waitForConnectorToStart(final String name, final int numTasks) throws InterruptedException {
+        TestUtils.waitForCondition(
+                () -> assertConnectorAndTasksRunning(name, numTasks).orElse(false),
+                CONNECTOR_STARTUP_DURATION_MS,
+                "Connector tasks did not start in time."
+        );
+        return System.currentTimeMillis();
+    }
+
+    Optional<Boolean> assertConnectorAndTasksRunning(final String connectorName, final int numTasks) {
+        try {
+            final var info = connect.connectorStatus(connectorName);
+            final boolean result = info != null
+                    && info.tasks().size() >= numTasks
+                    && info.connector().state().equals(AbstractStatus.State.RUNNING.toString())
+                    && info.tasks().stream().allMatch(s -> s.state().equals(AbstractStatus.State.RUNNING.toString()));
+            return Optional.of(result);
+        } catch (final Exception e) {
+            LOGGER.error("Could not check connector state info.");
+            return Optional.empty();
+        }
+    }
+
+    Map<String, String> connectorProperties() {
+        final var props = new HashMap<>(getDefaultProperties());
+        props.put(CONNECTOR_CLASS_CONFIG, OpensearchSinkConnector.class.getName());
+        props.put(TOPICS_CONFIG, topicName);
+        props.put(TASKS_MAX_CONFIG, Integer.toString(1));
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+        props.put("value.converter." + SCHEMAS_ENABLE_CONFIG, "false");
+        props.put(KEY_IGNORE_CONFIG, "true");
+        props.put(SCHEMA_IGNORE_CONFIG, "true");
+        return props;
+    }
+
+    void writeRecords(final int numRecords) {
+        for (int i = 0; i < numRecords; i++) {
+            connect.kafka().produce(
+                    topicName,
+                    String.valueOf(i),
+                    String.format("{\"doc_num\":%d}", i)
+            );
+        }
+    }
+
+}

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchClientIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchClientIT.java
@@ -19,6 +19,7 @@ package io.aiven.kafka.connect.opensearch;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -28,6 +29,7 @@ import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.indices.CreateDataStreamRequest;
 import org.opensearch.client.indices.CreateIndexRequest;
+import org.opensearch.client.indices.GetDataStreamRequest;
 import org.opensearch.client.indices.GetMappingsRequest;
 import org.opensearch.client.indices.PutComposableIndexTemplateRequest;
 import org.opensearch.cluster.metadata.ComposableIndexTemplate;
@@ -91,7 +93,30 @@ public class OpensearchClientIT extends AbstractIT {
     }
 
     @Test
-    void createIndexDoesNotCreateAlreadyExistingDatastream() throws Exception {
+    void createIndexTemplateAndDataStream() throws Exception {
+        final var props = new HashMap<>(getDefaultProperties());
+        props.put(OpensearchSinkConnectorConfig.DATA_STREAM_PREFIX, "some_data_stream");
+        final var config = new OpensearchSinkConnectorConfig(props);
+
+        opensearchClient.createIndexTemplateAndDataStream(
+                config.dataStreamPrefix().get(), config.dataStreamTimestampField());
+
+        assertTrue(
+                opensearchClient.dataStreamIndexTemplateExists(
+                        String.format(OpensearchClient.DATA_STREAM_TEMPLATE_NAME_PATTERN, "some_data_stream")
+                )
+        );
+        final var dataStreams = opensearchClient.client.indices().getDataStream(
+                new GetDataStreamRequest("some_data_stream"),
+                RequestOptions.DEFAULT
+        ).getDataStreams();
+        assertFalse(dataStreams.isEmpty());
+        assertEquals(1, dataStreams.size());
+        assertEquals("some_data_stream", dataStreams.get(0).getName());
+    }
+
+    @Test
+    void createIndexDoesNotCreateAlreadyExistingDataStream() throws Exception {
         final var config = new OpensearchSinkConnectorConfig(getDefaultProperties());
         final OpensearchClient tmpClient = new OpensearchClient(config);
 

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorIT.java
@@ -17,95 +17,26 @@
 
 package io.aiven.kafka.connect.opensearch;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
-import org.apache.kafka.connect.json.JsonConverter;
-import org.apache.kafka.connect.runtime.AbstractStatus;
-import org.apache.kafka.connect.storage.StringConverter;
-import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
-import org.apache.kafka.test.TestUtils;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG;
-import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.SCHEMA_IGNORE_CONFIG;
-import static org.apache.kafka.connect.json.JsonConverterConfig.SCHEMAS_ENABLE_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
-import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class OpensearchSinkConnectorIT extends AbstractIT {
+public class OpensearchSinkConnectorIT extends AbstractKafkaConnectIT {
 
     static final Logger LOGGER = LoggerFactory.getLogger(OpensearchSinkConnectorIT.class);
 
-    static final long CONNECTOR_STARTUP_DURATION_MS = TimeUnit.MINUTES.toMillis(60);
-
-    static final String TOPIC_NAME = "super_topic";
-
     static final String CONNECTOR_NAME = "os-sink-connector";
 
-    EmbeddedConnectCluster connect;
+    static final String TOPIC_NAME = "os-topic";
 
-    @BeforeEach
-    void startConnect() {
-        connect = new EmbeddedConnectCluster.Builder()
-                .name("elasticsearch-it-connect-cluster")
-                .build();
-        connect.start();
-        connect.kafka().createTopic(TOPIC_NAME);
-    }
-
-    @AfterEach
-    void stopConnect() {
-        connect.stop();
-    }
-
-    long waitForConnectorToStart(final String name, final int numTasks) throws InterruptedException {
-        TestUtils.waitForCondition(
-                () -> assertConnectorAndTasksRunning(name, numTasks).orElse(false),
-                CONNECTOR_STARTUP_DURATION_MS,
-                "Connector tasks did not start in time."
-        );
-        return System.currentTimeMillis();
-    }
-
-    Optional<Boolean> assertConnectorAndTasksRunning(final String connectorName, final int numTasks) {
-        try {
-            final var info = connect.connectorStatus(connectorName);
-            final boolean result = info != null
-                    && info.tasks().size() >= numTasks
-                    && info.connector().state().equals(AbstractStatus.State.RUNNING.toString())
-                    && info.tasks().stream().allMatch(s -> s.state().equals(AbstractStatus.State.RUNNING.toString()));
-            return Optional.of(result);
-        } catch (final Exception e) {
-            LOGGER.error("Could not check connector state info.");
-            return Optional.empty();
-        }
-    }
-
-    Map<String, String> connectorProperties() {
-        final var props = new HashMap<>(getDefaultProperties());
-        props.put(CONNECTOR_CLASS_CONFIG, OpensearchSinkConnector.class.getName());
-        props.put(TOPICS_CONFIG, TOPIC_NAME);
-        props.put(TASKS_MAX_CONFIG, Integer.toString(1));
-        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
-        props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
-        props.put("value.converter." + SCHEMAS_ENABLE_CONFIG, "false");
-        props.put(KEY_IGNORE_CONFIG, "true");
-        props.put(SCHEMA_IGNORE_CONFIG, "true");
-        return props;
+    public OpensearchSinkConnectorIT() {
+        super(TOPIC_NAME, CONNECTOR_NAME);
     }
 
     @Test
@@ -115,9 +46,9 @@ public class OpensearchSinkConnectorIT extends AbstractIT {
 
         writeRecords(10);
 
-        waitForRecords(10);
+        waitForRecords(TOPIC_NAME, 10);
 
-        for (final var hit : search()) {
+        for (final var hit : search(TOPIC_NAME)) {
             final var id = (Integer) hit.getSourceAsMap().get("doc_num");
             assertNotNull(id);
             assertTrue(id < 10);
@@ -136,15 +67,6 @@ public class OpensearchSinkConnectorIT extends AbstractIT {
         );
     }
 
-    void writeRecords(final int numRecords) {
-        for (int i = 0; i < numRecords; i++) {
-            connect.kafka().produce(
-                    TOPIC_NAME,
-                    String.valueOf(i),
-                    String.format("{\"doc_num\":%d}", i)
-            );
-        }
-    }
 
 
 }

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkDataStreamConnectorIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkDataStreamConnectorIT.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2021 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.concurrent.TimeUnit;
+
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.indices.DataStreamsStatsRequest;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OpensearchSinkDataStreamConnectorIT extends AbstractKafkaConnectIT {
+
+    static final Logger LOGGER = LoggerFactory.getLogger(OpensearchSinkConnectorIT.class);
+
+    static final long CONNECTOR_STARTUP_DURATION_MS = TimeUnit.MINUTES.toMillis(60);
+
+    static final String TOPIC_NAME = "ds-topic";
+
+    static final String DATA_STREAM_PREFIX = "os-data-stream";
+
+    static final String DATA_STREAM_PREFIX_WITH_TIMESTAMP = "os-data-stream-ts";
+
+    static final String DATA_STREAM_WITH_PREFIX_INDEX_NAME = String.format("%s-%s", DATA_STREAM_PREFIX, TOPIC_NAME);
+
+    static final String DATA_STREAM_PREFIX_WITH_TIMESTAMP_INDEX_NAME =
+            String.format("%s-%s", DATA_STREAM_PREFIX_WITH_TIMESTAMP, TOPIC_NAME);
+    static final String CONNECTOR_NAME = "os-ds-sink-connector";
+
+    public OpensearchSinkDataStreamConnectorIT() {
+        super(TOPIC_NAME, CONNECTOR_NAME);
+    }
+
+    @Test
+    void testConnector() throws Exception {
+        final var props = connectorProperties();
+        props.put(OpensearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true");
+        connect.configureConnector(CONNECTOR_NAME, props);
+
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+        writeRecords(10);
+
+        waitForRecords(TOPIC_NAME, 10);
+
+        assertDataStream(TOPIC_NAME);
+        assertDocs(TOPIC_NAME, OpensearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_FIELD_DEFAULT);
+    }
+
+    @Test
+    void testConnectorWithDataStreamCustomTimestamp() throws Exception {
+        final var props = connectorProperties();
+        props.put(OpensearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true");
+        props.put(OpensearchSinkConnectorConfig.DATA_STREAM_PREFIX, DATA_STREAM_PREFIX_WITH_TIMESTAMP);
+        props.put(OpensearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_FIELD, "custom_timestamp");
+        connect.configureConnector(CONNECTOR_NAME, props);
+
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+        for (int i = 0; i < 10; i++) {
+            connect.kafka().produce(
+                    topicName,
+                    String.valueOf(i),
+                    String.format("{\"doc_num\":%d, \"custom_timestamp\": %s}", i, System.currentTimeMillis())
+            );
+        }
+
+        waitForRecords(DATA_STREAM_PREFIX_WITH_TIMESTAMP_INDEX_NAME, 10);
+
+        assertDataStream(DATA_STREAM_PREFIX_WITH_TIMESTAMP_INDEX_NAME);
+        assertDocs(DATA_STREAM_PREFIX_WITH_TIMESTAMP_INDEX_NAME, "custom_timestamp");
+    }
+
+    @Test
+    void testConnectorWithDataStreamPrefix() throws Exception {
+        final var props = connectorProperties();
+        props.put(OpensearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true");
+        props.put(OpensearchSinkConnectorConfig.DATA_STREAM_PREFIX, DATA_STREAM_PREFIX);
+        connect.configureConnector(CONNECTOR_NAME, props);
+
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+        writeRecords(10);
+        waitForRecords(DATA_STREAM_WITH_PREFIX_INDEX_NAME, 10);
+
+        assertDataStream(DATA_STREAM_WITH_PREFIX_INDEX_NAME);
+        assertDocs(
+                DATA_STREAM_WITH_PREFIX_INDEX_NAME,
+                OpensearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_FIELD_DEFAULT
+        );
+    }
+
+    void assertDataStream(final String dataStreamName) throws Exception {
+        final var dsStats = opensearchClient.client.indices()
+                .dataStreamsStats(
+                        new DataStreamsStatsRequest(dataStreamName), RequestOptions.DEFAULT
+                );
+
+        assertEquals(1, dsStats.getDataStreamCount());
+        assertEquals(1, dsStats.getBackingIndices());
+        assertTrue(dsStats.getDataStreams().containsKey(dataStreamName));
+    }
+
+    void assertDocs(final String dataStreamIndexName, final String timestampFieldName) throws Exception {
+        for (final var hit : search(dataStreamIndexName)) {
+            final var id = (Integer) hit.getSourceAsMap().get("doc_num");
+            final var timestamp = (Long) hit.getSourceAsMap().get(timestampFieldName);
+            System.out.println(hit.getSourceAsMap());
+            assertNotNull(id);
+            assertNotNull(timestamp);
+            assertTrue(id < 10);
+        }
+    }
+
+}

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskIT.java
@@ -55,6 +55,8 @@ public class OpensearchSinkTaskIT extends AbstractIT {
 
     private static final int PARTITION_1 = 12;
 
+    public static final String TOPIC_NAME = "os-data-test";
+
     @AfterEach
     void tearDown() throws Exception {
         if (opensearchClient.indexExists(TOPIC_NAME)) {
@@ -88,9 +90,9 @@ public class OpensearchSinkTaskIT extends AbstractIT {
         );
 
         assertTrue(opensearchClient.indexExists(TOPIC_NAME));
-        waitForRecords(1);
+        waitForRecords(TOPIC_NAME, 1);
 
-        for (final var hint : search()) {
+        for (final var hint : search(TOPIC_NAME)) {
             if (hint.getId().equals("key")) {
                 assertEquals(Base64.getEncoder().encodeToString(new byte[]{42}), hint.getSourceAsMap().get("bytes"));
             }
@@ -114,7 +116,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
                 List.of(new SinkRecord(TOPIC_NAME, PARTITION_1,
                         Schema.STRING_SCHEMA, "key", structSchema, struct, 0))
         );
-        for (final var hint : search()) {
+        for (final var hint : search(TOPIC_NAME)) {
             if (hint.getId().equals("key")) {
                 assertEquals(0.02d, hint.getSourceAsMap().get("decimal"));
             }
@@ -142,7 +144,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
             );
             assertTrue(opensearchClient.indexExists(TOPIC_NAME));
             opensearchSinkTask.flush(null);
-            waitForRecords(2);
+            waitForRecords(TOPIC_NAME, 2);
             opensearchSinkTask.put(
                     List.of(
                             new SinkRecord(TOPIC_NAME, PARTITION_1, Schema.STRING_SCHEMA,
@@ -152,7 +154,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
                     )
             );
             opensearchSinkTask.flush(null);
-            waitForRecords(4);
+            waitForRecords(TOPIC_NAME, 4);
         } finally {
             opensearchSinkTask.stop();
         }
@@ -194,7 +196,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
                 )
         );
         assertTrue(opensearchClient.indexExists(TOPIC_NAME));
-        waitForRecords(2);
+        waitForRecords(TOPIC_NAME, 2);
         // Then, write a record with the same key as the first inserted record but a null value
         runTask(
                 getDefaultTaskProperties(false, RecordConverter.BehaviorOnNullValues.DELETE),
@@ -202,7 +204,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
                         new SinkRecord(TOPIC_NAME, PARTITION_1, Schema.STRING_SCHEMA, key1, schema, null, 2)
                 )
         );
-        waitForRecords(1);
+        waitForRecords(TOPIC_NAME, 1);
     }
 
     @Test
@@ -215,7 +217,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
                 )
         );
         assertTrue(opensearchClient.indexExists(TOPIC_NAME));
-        waitForRecords(0);
+        waitForRecords(TOPIC_NAME, 0);
     }
 
     @Test
@@ -265,7 +267,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
                 )
         );
         assertTrue(opensearchClient.indexExists(TOPIC_NAME));
-        waitForRecords(1);
+        waitForRecords(TOPIC_NAME, 1);
     }
 
     @Test
@@ -282,7 +284,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
                         Schema.STRING_SCHEMA, "key", mapSchema, map, 0))
         );
         assertTrue(opensearchClient.indexExists(TOPIC_NAME));
-        waitForRecords(1);
+        waitForRecords(TOPIC_NAME, 1);
     }
 
     @Test
@@ -292,7 +294,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
                 prepareData(2)
         );
         assertTrue(opensearchClient.indexExists(TOPIC_NAME));
-        waitForRecords(2);
+        waitForRecords(TOPIC_NAME, 2);
     }
 
     @Test
@@ -304,7 +306,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
                 prepareData(2)
         );
         assertTrue(opensearchClient.indexExists(TOPIC_NAME));
-        waitForRecords(2);
+        waitForRecords(TOPIC_NAME, 2);
     }
 
     @Test
@@ -314,7 +316,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
         props.put(KEY_IGNORE_ID_STRATEGY_CONFIG, "none");
         runTask(props, prepareData(numRecords));
         assertTrue(opensearchClient.indexExists(TOPIC_NAME));
-        waitForRecords(numRecords);
+        waitForRecords(TOPIC_NAME, numRecords);
     }
 
     private List<SinkRecord> prepareData(final int numRecords) {

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchClient.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchClient.java
@@ -22,6 +22,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 
@@ -35,10 +36,16 @@ import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.indices.ComposableIndexTemplateExistRequest;
+import org.opensearch.client.indices.CreateDataStreamRequest;
 import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.client.indices.GetMappingsRequest;
+import org.opensearch.client.indices.PutComposableIndexTemplateRequest;
 import org.opensearch.client.indices.PutMappingRequest;
+import org.opensearch.cluster.metadata.ComposableIndexTemplate;
+import org.opensearch.cluster.metadata.ComposableIndexTemplate.DataStreamTemplate;
+import org.opensearch.cluster.metadata.DataStream.TimestampField;
 
 import io.aiven.kafka.connect.opensearch.spi.ClientsConfiguratorProvider;
 import io.aiven.kafka.connect.opensearch.spi.OpensearchClientConfigurator;
@@ -63,12 +70,14 @@ public class OpensearchClient implements AutoCloseable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchClient.class);
 
+    public static final String DATA_STREAM_TEMPLATE_NAME_PATTERN = "%s-connector-data-stream-template";
+
     private static final String RESOURCE_ALREADY_EXISTS_EXCEPTION = "resource_already_exists_exception";
 
     private static final String RESOURCE_ALREADY_EXISTS_AS_ALIAS = "already exists as alias";
 
     private static final String RESOURCE_ALREADY_EXISTS_AS_DATASTREAM =
-        "creates data streams only, use create data stream api instead";
+            "creates data streams only, use create data stream api instead";
 
     private static final String DEFAULT_OS_VERSION = "1.0.0";
 
@@ -119,6 +128,80 @@ public class OpensearchClient implements AutoCloseable {
         );
     }
 
+    protected boolean dataStreamIndexTemplateExists(final String dataStreamIndexTemplate) {
+        return withRetry(
+                String.format("check index template exists %s", dataStreamIndexTemplate),
+                () -> client.indices().existsIndexTemplate(
+                        new ComposableIndexTemplateExistRequest(dataStreamIndexTemplate),
+                        RequestOptions.DEFAULT
+                )
+        );
+    }
+
+    protected boolean createDatStreamIndexTemplate(final String dataStreamName, final String dataStreamTimestampField) {
+        final var dataStreamIndexTemplate = String.format(DATA_STREAM_TEMPLATE_NAME_PATTERN, dataStreamName);
+        if (!dataStreamIndexTemplateExists(dataStreamIndexTemplate)) {
+            return withRetry(
+                    String.format("create index template %s", dataStreamIndexTemplate),
+                    () -> {
+                        try {
+                            client.indices().putIndexTemplate(
+                                    new PutComposableIndexTemplateRequest()
+                                            .name(dataStreamIndexTemplate)
+                                            .indexTemplate(
+                                                    new ComposableIndexTemplate(
+                                                            List.of(dataStreamName),
+                                                            null,
+                                                            null,
+                                                            200L,
+                                                            null,
+                                                            null,
+                                                            new DataStreamTemplate(
+                                                                    new TimestampField(dataStreamTimestampField)
+                                                            )
+                                                    )
+                                            ),
+                                    RequestOptions.DEFAULT
+                            );
+                        } catch (final OpenSearchStatusException | IOException e) {
+                            if (!(e.getMessage().contains(RESOURCE_ALREADY_EXISTS_EXCEPTION))) {
+                                throw e;
+                            }
+                            return false;
+                        }
+                        return true;
+                    });
+        }
+        return true;
+    }
+
+    public boolean createIndexTemplateAndDataStream(
+            final String dataStreamName,
+            final String dataStreamTimestampField) {
+        if (createDatStreamIndexTemplate(dataStreamName, dataStreamTimestampField)) {
+            return withRetry(
+                    String.format("create data stream %s", dataStreamName),
+                    () -> {
+                        LOGGER.info("Create data stream {}", dataStreamName);
+                        try {
+                            client.indices().createDataStream(
+                                    new CreateDataStreamRequest(dataStreamName),
+                                    RequestOptions.DEFAULT
+                            );
+                            return true;
+                        } catch (final OpenSearchStatusException | IOException e) {
+                            if (!(e.getMessage().contains(RESOURCE_ALREADY_EXISTS_EXCEPTION)
+                                    || e.getMessage().contains(RESOURCE_ALREADY_EXISTS_AS_ALIAS)
+                                    || e.getMessage().contains(RESOURCE_ALREADY_EXISTS_AS_DATASTREAM))) {
+                                throw e;
+                            }
+                            return false;
+                        }
+                    });
+        }
+        return false;
+    }
+
     public boolean createIndex(final String index) {
         return withRetry(
                 String.format("create index %s", index),
@@ -128,8 +211,8 @@ public class OpensearchClient implements AutoCloseable {
                         return true;
                     } catch (final OpenSearchStatusException | IOException e) {
                         if (!(e.getMessage().contains(RESOURCE_ALREADY_EXISTS_EXCEPTION)
-                            || e.getMessage().contains(RESOURCE_ALREADY_EXISTS_AS_ALIAS)
-                            || e.getMessage().contains(RESOURCE_ALREADY_EXISTS_AS_DATASTREAM))) {
+                                || e.getMessage().contains(RESOURCE_ALREADY_EXISTS_AS_ALIAS)
+                                || e.getMessage().contains(RESOURCE_ALREADY_EXISTS_AS_DATASTREAM))) {
                             throw e;
                         }
                         return false;
@@ -195,14 +278,14 @@ public class OpensearchClient implements AutoCloseable {
                     .build();
 
             final Collection<OpensearchClientConfigurator> configurators = ClientsConfiguratorProvider
-                .forOpensearch(config);
+                    .forOpensearch(config);
             configurators.forEach(configurator -> {
                 if (configurator.apply(config, httpClientBuilder)) {
                     LOGGER.debug("Successfuly applied " + configurator.getClass().getName()
-                        + " configurator to OpensearchClient");
+                            + " configurator to OpensearchClient");
                 }
             });
-            
+
             httpClientBuilder
                     .setConnectionManager(createConnectionManager())
                     .setDefaultRequestConfig(requestConfig);
@@ -234,9 +317,9 @@ public class OpensearchClient implements AutoCloseable {
                 connectionManager.setMaxTotal(maxPerRoute * config.httpHosts().length);
                 return connectionManager;
             } catch (final IOReactorException
-                    | NoSuchAlgorithmException
-                    | KeyStoreException
-                    | KeyManagementException e) {
+                           | NoSuchAlgorithmException
+                           | KeyStoreException
+                           | KeyManagementException e) {
                 throw new ConnectException("Unable to open ElasticsearchClient.", e);
             }
         }

--- a/src/test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfigTest.java
@@ -147,4 +147,22 @@ public class OpensearchSinkConnectorConfigTest {
         assertEquals(keyIgnoreStrategy, config.docIdStrategy("topic2"));
         assertEquals(DocumentIDStrategy.RECORD_KEY, config.docIdStrategy("otherTopic"));
     }
+
+    @Test
+    public void dataStreamConfig() {
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost");
+        props.put(OpensearchSinkConnectorConfig.DATA_STREAM_PREFIX, "aaaa");
+
+        final var defaultConfig = new OpensearchSinkConnectorConfig(props);
+
+        assertEquals("aaaa", defaultConfig.dataStreamPrefix().get());
+        assertEquals("@timestamp", defaultConfig.dataStreamTimestampField());
+
+        props.put(OpensearchSinkConnectorConfig.DATA_STREAM_PREFIX, "bbbb");
+        props.put(OpensearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_FIELD, "custom_timestamp");
+        final var customConfig = new OpensearchSinkConnectorConfig(props);
+        assertEquals("bbbb", customConfig.dataStreamPrefix().get());
+        assertEquals("custom_timestamp", customConfig.dataStreamTimestampField());
+    }
+
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -18,4 +18,5 @@ log4j.rootLogger=INFO, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+log4j.logger.io.aiven.kafka.connect.opensearch=DEBUG
 log4j.logger.org.apache.kafka=ERROR


### PR DESCRIPTION
Add support for data stream. 

The connector works now in 2 possible configurations:
- Sync topics data into indices 
- Sync topics data into data streams   