### PR TITLE
Refactor RecordConverter class

### DIFF
--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskIT.java
@@ -80,7 +80,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
         struct.put("bytes", new byte[]{42});
 
         runTask(
-                getDefaultTaskProperties(true, RecordConverter.BehaviorOnNullValues.DEFAULT),
+                getDefaultTaskProperties(true, BehaviorOnNullValues.DEFAULT),
                 List.of(
                         new SinkRecord(
                                 TOPIC_NAME, PARTITION_1,
@@ -112,7 +112,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
         final Struct struct = new Struct(structSchema);
         struct.put("decimal", decimal);
         runTask(
-                getDefaultTaskProperties(false, RecordConverter.BehaviorOnNullValues.DEFAULT),
+                getDefaultTaskProperties(false, BehaviorOnNullValues.DEFAULT),
                 List.of(new SinkRecord(TOPIC_NAME, PARTITION_1,
                         Schema.STRING_SCHEMA, "key", structSchema, struct, 0))
         );
@@ -133,7 +133,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
 
         final var opensearchSinkTask = new OpensearchSinkTask();
         try {
-            opensearchSinkTask.start(getDefaultTaskProperties(true, RecordConverter.BehaviorOnNullValues.DEFAULT));
+            opensearchSinkTask.start(getDefaultTaskProperties(true, BehaviorOnNullValues.DEFAULT));
             opensearchSinkTask.put(
                     List.of(
                             new SinkRecord(TOPIC_NAME, PARTITION_1,
@@ -167,7 +167,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
         final var otherSchema = createOtherSchema();
         final var otherRecord = createOtherRecord(otherSchema);
         assertThrows(ConnectException.class, () -> runTask(
-                getDefaultTaskProperties(true, RecordConverter.BehaviorOnNullValues.DEFAULT),
+                getDefaultTaskProperties(true, BehaviorOnNullValues.DEFAULT),
                 List.of(new SinkRecord(
                                 TOPIC_NAME, PARTITION_1,
                                 Schema.STRING_SCHEMA, "key", otherSchema, otherRecord, 0),
@@ -187,7 +187,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
 
         // First, write a couple of actual (non-null-valued) records
         runTask(
-                getDefaultTaskProperties(false, RecordConverter.BehaviorOnNullValues.DELETE),
+                getDefaultTaskProperties(false, BehaviorOnNullValues.DELETE),
                 List.of(
                         new SinkRecord(TOPIC_NAME, PARTITION_1,
                                 Schema.STRING_SCHEMA, key1, schema, record, 0),
@@ -199,7 +199,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
         waitForRecords(TOPIC_NAME, 2);
         // Then, write a record with the same key as the first inserted record but a null value
         runTask(
-                getDefaultTaskProperties(false, RecordConverter.BehaviorOnNullValues.DELETE),
+                getDefaultTaskProperties(false, BehaviorOnNullValues.DELETE),
                 List.of(
                         new SinkRecord(TOPIC_NAME, PARTITION_1, Schema.STRING_SCHEMA, key1, schema, null, 2)
                 )
@@ -210,7 +210,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
     @Test
     public void testDeleteWithNullKey() throws Exception {
         runTask(
-                getDefaultTaskProperties(false, RecordConverter.BehaviorOnNullValues.DELETE),
+                getDefaultTaskProperties(false, BehaviorOnNullValues.DELETE),
                 List.of(
                         new SinkRecord(TOPIC_NAME, PARTITION_1,
                                 Schema.STRING_SCHEMA, null, createSchema(), null, 0)
@@ -225,7 +225,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
         assertThrows(
                 ConnectException.class,
                 () -> runTask(
-                        getDefaultTaskProperties(false, RecordConverter.BehaviorOnNullValues.FAIL),
+                        getDefaultTaskProperties(false, BehaviorOnNullValues.FAIL),
                         List.of(
                                 new SinkRecord(TOPIC_NAME, PARTITION_1,
                                         Schema.STRING_SCHEMA, "key", createSchema(), null, 0)
@@ -237,7 +237,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
     @Test
     public void testIgnoreNullValue() throws Exception {
         runTask(
-                getDefaultTaskProperties(false, RecordConverter.BehaviorOnNullValues.IGNORE),
+                getDefaultTaskProperties(false, BehaviorOnNullValues.IGNORE),
                 List.of(
                         new SinkRecord(TOPIC_NAME, PARTITION_1,
                                 Schema.STRING_SCHEMA, "key", createSchema(), null, 0)
@@ -260,7 +260,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
         struct.put("map", map);
 
         runTask(
-                getDefaultTaskProperties(false, RecordConverter.BehaviorOnNullValues.DEFAULT),
+                getDefaultTaskProperties(false, BehaviorOnNullValues.DEFAULT),
                 List.of(
                         new SinkRecord(TOPIC_NAME, PARTITION_1,
                                 Schema.STRING_SCHEMA, "key", structSchema, struct, 0)
@@ -279,7 +279,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
         map.put("Two", 2);
 
         runTask(
-                getDefaultTaskProperties(false, RecordConverter.BehaviorOnNullValues.DEFAULT),
+                getDefaultTaskProperties(false, BehaviorOnNullValues.DEFAULT),
                 List.of(new SinkRecord(TOPIC_NAME, PARTITION_1,
                         Schema.STRING_SCHEMA, "key", mapSchema, map, 0))
         );
@@ -290,7 +290,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
     @Test
     public void testWriterIgnoreKey() throws Exception {
         runTask(
-                getDefaultTaskProperties(true, RecordConverter.BehaviorOnNullValues.DEFAULT),
+                getDefaultTaskProperties(true, BehaviorOnNullValues.DEFAULT),
                 prepareData(2)
         );
         assertTrue(opensearchClient.indexOrDataStreamExists(TOPIC_NAME));
@@ -299,10 +299,10 @@ public class OpensearchSinkTaskIT extends AbstractIT {
 
     @Test
     public void testWriterIgnoreSchema() throws Exception {
-        final var props = getDefaultTaskProperties(true, RecordConverter.BehaviorOnNullValues.DEFAULT);
+        final var props = getDefaultTaskProperties(true, BehaviorOnNullValues.DEFAULT);
         props.put(SCHEMA_IGNORE_CONFIG, "true");
         runTask(
-                getDefaultTaskProperties(true, RecordConverter.BehaviorOnNullValues.DEFAULT),
+                getDefaultTaskProperties(true, BehaviorOnNullValues.DEFAULT),
                 prepareData(2)
         );
         assertTrue(opensearchClient.indexOrDataStreamExists(TOPIC_NAME));
@@ -312,7 +312,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
     @Test
     public void testKeyIgnoreStrategy() throws Exception {
         final int numRecords = 5;
-        final var props = getDefaultTaskProperties(true, RecordConverter.BehaviorOnNullValues.DEFAULT);
+        final var props = getDefaultTaskProperties(true, BehaviorOnNullValues.DEFAULT);
         props.put(KEY_IGNORE_ID_STRATEGY_CONFIG, "none");
         runTask(props, prepareData(numRecords));
         assertTrue(opensearchClient.indexOrDataStreamExists(TOPIC_NAME));
@@ -330,7 +330,7 @@ public class OpensearchSinkTaskIT extends AbstractIT {
     }
 
     Map<String, String> getDefaultTaskProperties(final boolean ignoreKey,
-                                                 final RecordConverter.BehaviorOnNullValues behaviorOnNullValues) {
+                                                 final BehaviorOnNullValues behaviorOnNullValues) {
         final var props = new HashMap<>(getDefaultProperties());
         props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, behaviorOnNullValues.name());
         props.put(DROP_INVALID_MESSAGE_CONFIG, "false");

--- a/src/main/java/io/aiven/kafka/connect/opensearch/BehaviorOnNullValues.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/BehaviorOnNullValues.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.Locale;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+public enum BehaviorOnNullValues {
+    IGNORE,
+    DELETE,
+    FAIL;
+
+    public static final BehaviorOnNullValues DEFAULT = IGNORE;
+
+    // Want values for "behavior.on.null.values" property to be case-insensitive
+    public static final ConfigDef.Validator VALIDATOR = new ConfigDef.Validator() {
+        private final ConfigDef.ValidString validator = ConfigDef.ValidString.in(names());
+
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (value instanceof String) {
+                final String lowerStringValue = ((String) value).toLowerCase(Locale.ROOT);
+                validator.ensureValid(name, lowerStringValue);
+            } else {
+                validator.ensureValid(name, value);
+            }
+        }
+
+        // Overridden here so that ConfigDef.toEnrichedRst shows possible values correctly
+        @Override
+        public String toString() {
+            return validator.toString();
+        }
+
+    };
+
+    public static String[] names() {
+        final BehaviorOnNullValues[] behaviors = values();
+        final String[] result = new String[behaviors.length];
+
+        for (int i = 0; i < behaviors.length; i++) {
+            result[i] = behaviors[i].toString();
+        }
+
+        return result;
+    }
+
+    public static BehaviorOnNullValues forValue(final String value) {
+        return valueOf(value.toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -409,8 +409,8 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
         ).define(
                 BEHAVIOR_ON_NULL_VALUES_CONFIG,
                 Type.STRING,
-                RecordConverter.BehaviorOnNullValues.DEFAULT.toString(),
-                RecordConverter.BehaviorOnNullValues.VALIDATOR,
+                BehaviorOnNullValues.DEFAULT.toString(),
+                BehaviorOnNullValues.VALIDATOR,
                 Importance.LOW,
                 BEHAVIOR_ON_NULL_VALUES_DOC,
                 DATA_CONVERSION_GROUP_NAME,
@@ -573,7 +573,11 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
         return getBoolean(OpensearchSinkConnectorConfig.DROP_INVALID_MESSAGE_CONFIG);
     }
 
-    public DocumentIDStrategy docIdStrategy(final String topic) {
+    public RequestBuilder createRequestBuilder() {
+        return RequestBuilder.create(this);
+    }
+
+    protected DocumentIDStrategy docIdStrategy(final String topic) {
         return (ignoreKey() || topicIgnoreKey().contains(topic))
             ? DocumentIDStrategy.fromString(getString(KEY_IGNORE_ID_STRATEGY_CONFIG))
                 : DocumentIDStrategy.RECORD_KEY;
@@ -616,8 +620,8 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
         return ignoreSchema() || topicIgnoreSchema().contains(topic);
     }
 
-    public RecordConverter.BehaviorOnNullValues behaviorOnNullValues() {
-        return RecordConverter.BehaviorOnNullValues.forValue(
+    public BehaviorOnNullValues behaviorOnNullValues() {
+        return BehaviorOnNullValues.forValue(
                 getString(OpensearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG)
         );
     }

--- a/src/main/java/io/aiven/kafka/connect/opensearch/RequestBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/RequestBuilder.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.Objects;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.common.xcontent.XContentType;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_FIELD_DEFAULT;
+
+@FunctionalInterface
+interface RequestBuilder {
+
+    @FunctionalInterface
+    interface SetDocumentIDStrategy {
+        SetPayloadBuilder withDocumentIDStrategy(final DocumentIDStrategy documentIDStrategy);
+    }
+
+    @FunctionalInterface
+    interface SetPayloadBuilder {
+        RequestBuilder withPayloadBuilder(final PayloadBuilder payloadBuilder);
+    }
+
+    @FunctionalInterface
+    interface SetObjectMapper {
+        SetDocumentIDStrategy withObjectMapper(final ObjectMapper objectMapper);
+    }
+
+    @FunctionalInterface
+    interface SetDataStreamTimestampField {
+        SetObjectMapper withDataStreamTimestampField(final String dataStreamTimestampField);
+    }
+
+    DocWriteRequest<?> build(final String index, final SinkRecord record);
+
+    static RequestBuilder create(final OpensearchSinkConnectorConfig config) {
+        return (index, record) -> {
+            final var payloadBuilder = new PayloadBuilder(config);
+            final var objectMapper = new ObjectMapper();
+            if (Objects.isNull(record.value())) {
+                switch (config.behaviorOnNullValues()) {
+                    case IGNORE:
+                        return null;
+                    case DELETE:
+                        if (Objects.isNull(record.key())) {
+                            // Since the record key is used as the ID of the index to delete and we don't have a key
+                            // for this record, we can't delete anything anyways, so we ignore the record.
+                            // We can also disregard the value of the ignoreKey parameter, since even if it's true
+                            // the resulting index we'd try to delete would be based solely off topic/partition/
+                            // offset information for the SinkRecord. Since that information is guaranteed to be
+                            // unique per message, we can be confident that there wouldn't be any corresponding
+                            // index present in ES to delete anyways.
+                            return null;
+                        }
+                        break;
+                    case FAIL:
+                    default:
+                        throw new DataException(String.format(
+                                "Sink record with key of %s and null value encountered for topic/partition/offset "
+                                        + "%s/%s/%s (to ignore future records like this "
+                                        + "change the configuration property "
+                                        + "'%s' from '%s' to '%s')",
+                                record.key(),
+                                record.topic(),
+                                record.kafkaPartition(),
+                                record.kafkaOffset(),
+                                OpensearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                                BehaviorOnNullValues.FAIL,
+                                BehaviorOnNullValues.IGNORE
+                        ));
+                }
+            }
+            if (Objects.isNull(record.value())) {
+                return config.docIdStrategy(record.topic()).updateRequest(new DeleteRequest(index), record);
+            }
+            if (config.dataStreamEnabled()) {
+                return buildDataStreamRequest()
+                        .withDataStreamTimestampField(config.dataStreamTimestampField())
+                        .withObjectMapper(objectMapper)
+                        .withDocumentIDStrategy(config.docIdStrategy(record.topic()))
+                        .withPayloadBuilder(payloadBuilder)
+                        .build(index, record);
+            } else {
+                return buildInsertRequest()
+                        .withDocumentIDStrategy(config.docIdStrategy(record.topic()))
+                        .withPayloadBuilder(payloadBuilder)
+                        .build(index, record);
+            }
+        };
+    }
+
+    private static SetDocumentIDStrategy buildInsertRequest() {
+        return documentIDStrategy -> payloadBuilder -> (index, record) ->
+                documentIDStrategy
+                        .updateRequest(
+                                new IndexRequest()
+                                        .index(index)
+                                        .opType(DocWriteRequest.OpType.INDEX)
+                                        .source(payloadBuilder.buildPayload(record), XContentType.JSON),
+                                record);
+    }
+
+    private static SetDataStreamTimestampField buildDataStreamRequest() {
+        return dataStreamTimestampField -> objectMapper -> documentIDStrategy -> payloadBuilder -> (index, record) -> {
+            var payload = payloadBuilder.buildPayload(record);
+            if (DATA_STREAM_TIMESTAMP_FIELD_DEFAULT.equals(dataStreamTimestampField)) {
+                try {
+                    final var jsonObject = readJsonObject(payload, objectMapper);
+                    if (!jsonObject.has(DATA_STREAM_TIMESTAMP_FIELD_DEFAULT)) {
+                        jsonObject.put(DATA_STREAM_TIMESTAMP_FIELD_DEFAULT, record.timestamp());
+                        payload = objectMapper.writeValueAsString(jsonObject);
+                    }
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return documentIDStrategy.updateRequest(
+                    new IndexRequest()
+                            .index(index)
+                            .opType(DocWriteRequest.OpType.CREATE)
+                            .source(payload, XContentType.JSON),
+                    record
+            );
+        };
+    }
+
+    private static ObjectNode readJsonObject(final String payload, final ObjectMapper objectMapper)
+            throws JsonProcessingException {
+        final var json = objectMapper.readTree(payload);
+        if (!json.isObject()) {
+            throw new DataException(
+                    "JSON payload is a type of " + json.getNodeType() + ". Required is JSON Object.");
+        }
+        return (ObjectNode) json;
+    }
+
+}

--- a/src/test/java/io/aiven/kafka/connect/opensearch/MappingTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/MappingTest.java
@@ -177,17 +177,17 @@ public class MappingTest {
         final var props = Map.of(
                 OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost",
                 OpensearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
-                RecordConverter.BehaviorOnNullValues.IGNORE.toString(),
+                BehaviorOnNullValues.IGNORE.toString(),
                 OpensearchSinkConnectorConfig.COMPACT_MAP_ENTRIES_CONFIG, "true"
         );
-        final RecordConverter converter = new RecordConverter(new OpensearchSinkConnectorConfig(props));
+        final var payloadBuilder = new PayloadBuilder(new OpensearchSinkConnectorConfig(props));
         final Schema.Type schemaType = schema.type();
         switch (schemaType) {
             case ARRAY:
                 verifyMapping(schema.valueSchema(), mapping);
                 break;
             case MAP:
-                final Schema newSchema = converter.preProcessSchema(schema);
+                final Schema newSchema = payloadBuilder.preProcessSchema(schema);
                 final JsonObject mapProperties = mapping.get("properties").getAsJsonObject();
                 verifyMapping(
                         newSchema.keySchema(),

--- a/src/test/java/io/aiven/kafka/connect/opensearch/RequestBuilderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/RequestBuilderTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import org.opensearch.action.delete.DeleteRequest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RequestBuilderTest {
+
+    private String key;
+    private String topic;
+    private int partition;
+    private long offset;
+    private String index;
+    private Schema schema;
+
+    RequestBuilder requestBuilder;
+
+    @BeforeEach
+    public void setUp() {
+        requestBuilder = createPayloadBuilder(true, BehaviorOnNullValues.DEFAULT);
+        key = "key";
+        topic = "topic";
+        partition = 0;
+        offset = 0;
+        index = "index";
+        schema = SchemaBuilder
+                .struct()
+                .name("struct")
+                .field("string", Schema.STRING_SCHEMA)
+                .build();
+    }
+
+    @Test
+    public void ignoreOnNullValue() {
+        requestBuilder = createPayloadBuilder(true, BehaviorOnNullValues.IGNORE);
+        final SinkRecord sinkRecord = createSinkRecordWithValue(null);
+        assertNull(requestBuilder.build(index, sinkRecord));
+    }
+
+    @Test
+    public void deleteOnNullValue() {
+        requestBuilder = createPayloadBuilder(true, BehaviorOnNullValues.DELETE);
+
+        final SinkRecord sinkRecord = createSinkRecordWithValue(null);
+        final var deleteRecord = requestBuilder.build(index, sinkRecord);
+
+        assertTrue(deleteRecord instanceof DeleteRequest);
+        assertEquals(key, deleteRecord.id());
+        assertEquals(index, deleteRecord.index());
+    }
+
+    @Test
+    public void ignoreDeleteOnNullValueWithNullKey() {
+        requestBuilder = createPayloadBuilder(true, BehaviorOnNullValues.DELETE);
+        key = null;
+
+        final SinkRecord sinkRecord = createSinkRecordWithValue(null);
+        assertNull(requestBuilder.build(index, sinkRecord));
+    }
+
+    @Test
+    public void failOnNullValue() {
+        requestBuilder = createPayloadBuilder(true, BehaviorOnNullValues.FAIL);
+
+        final SinkRecord sinkRecord = createSinkRecordWithValue(null);
+        assertThrows(
+                DataException.class,
+                () -> requestBuilder.build(index, sinkRecord));
+    }
+
+    RequestBuilder createPayloadBuilder(final boolean useCompactMapEntries,
+                                        final BehaviorOnNullValues behaviorOnNullValues) {
+        final var props = Map.of(
+                OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost",
+                OpensearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                behaviorOnNullValues.toString(),
+                OpensearchSinkConnectorConfig.COMPACT_MAP_ENTRIES_CONFIG, Boolean.toString(useCompactMapEntries)
+        );
+        return RequestBuilder.create(new OpensearchSinkConnectorConfig(props));
+    }
+
+    public SinkRecord createSinkRecordWithValue(final Object value) {
+        return new SinkRecord(topic, partition, Schema.STRING_SCHEMA, key, schema, value, offset);
+    }
+
+}


### PR DESCRIPTION
The `RecordConverter` was refactored due to the fact that it was responsible for 2 different things in code.
- Convert record schema 
- Build OpenSearch request  
which created problems in case of maintenance and readability of the code.

For that it was splitted into 2 classes:
- `RequestBuilder` - wihch is responsible for building OpenSearch requests
- `PayloadBuilder` - which is responsible for converting record schema into request payload 


Signed-off-by: Andrey Pleskach <ples@aiven.io>