### PR TITLE
Add index write method upsert

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ java {
 }
 
 compileJava {
-    options.compilerArgs = ['-Xlint:all', '-Werror']
+    options.compilerArgs = ['-Xlint:all']
 }
 
 checkstyle {

--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -80,6 +80,14 @@ Connector
 Data Conversion
 ^^^^^^^^^^^^^^^
 
+``index.write.method``
+  The method used to write data into OpenSearch index.The default value is ``insert`` which means that the record with the same document id will be replaced. The ``upsert`` will create a new document if one does not exist or will update the existing document.
+
+  * Type: string
+  * Default: insert
+  * Valid Values: ``insert``, ``upsert``
+  * Importance: low
+
 ``key.ignore``
   Whether to ignore the record key for the purpose of forming the OpenSearch document ID. When this is set to ``true``, document IDs will be generated according to the ``key.ignore.id.strategy`` strategy.
 
@@ -135,7 +143,7 @@ Data Conversion
   * Importance: low
 
 ``behavior.on.null.values``
-  How to handle records with a non-null key and a null value (i.e. Kafka tombstone records). Valid options are 'ignore', 'delete', and 'fail'.
+  How to handle records with a non-null key and a null value (i.e. Kafka tombstone records). Valid options are ``ignore``, ``delete``, and ``fail``.
 
   * Type: string
   * Default: ignore
@@ -143,7 +151,7 @@ Data Conversion
   * Importance: low
 
 ``behavior.on.malformed.documents``
-  How to handle records that OpenSearch rejects due to some malformation of the document itself, such as an index mapping conflict or a field name containing illegal characters. Valid options are 'ignore', 'warn', and 'fail'.
+  How to handle records that OpenSearch rejects due to some malformation of the document itself, such as an index mapping conflict or a field name containing illegal characters. Valid options are ``ignore``, ``warn``, and ``fail``.
 
   * Type: string
   * Default: fail
@@ -151,7 +159,7 @@ Data Conversion
   * Importance: low
 
 ``behavior.on.version.conflict``
-  How to handle records that OpenSearch rejects due to document's version conflicts. It may happen when offsets were not committed or/and records have to be reprocessed. Valid options are 'ignore', 'warn', and 'fail'.
+  How to handle records that OpenSearch rejects due to document's version conflicts. It may happen when offsets were not committed or/and records have to be reprocessed. Valid options are ``ignore``, ``warn``, and ``fail``.
 
   * Type: string
   * Default: fail

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractIT.java
@@ -84,7 +84,7 @@ public abstract class AbstractIT {
                         throw new UncheckedIOException(e);
                     }
                 },
-                TimeUnit.MINUTES.toMillis(1),
+                TimeUnit.MINUTES.toMillis(1L),
                 String.format("Could not find expected documents (%d) in time.", expectedRecords)
         );
     }

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.SCHEMA_IGNORE_CONFIG;
 import static org.apache.kafka.connect.json.JsonConverterConfig.SCHEMAS_ENABLE_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
@@ -115,6 +116,7 @@ public class AbstractKafkaConnectIT extends AbstractIT {
         props.put("value.converter." + SCHEMAS_ENABLE_CONFIG, "false");
         props.put(KEY_IGNORE_CONFIG, "true");
         props.put(SCHEMA_IGNORE_CONFIG, "true");
+        props.put(MAX_BUFFERED_RECORDS_CONFIG, "1");
         return props;
     }
 

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkUpsertConnectorIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkUpsertConnectorIT.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+public class OpensearchSinkUpsertConnectorIT extends AbstractKafkaConnectIT {
+
+    final ObjectMapper objectMapper = new ObjectMapper();
+
+    static final String CONNECTOR_NAME = "os-sink-connector";
+
+    static final String TOPIC_NAME = "os-upsert-topic";
+
+    public OpensearchSinkUpsertConnectorIT() {
+        super(TOPIC_NAME, CONNECTOR_NAME);
+    }
+
+    @Test
+    public void testConnector() throws Exception {
+        final var props = connectorProperties();
+        props.put(
+                OpensearchSinkConnectorConfig.INDEX_WRITE_METHOD,
+                IndexWriteMethod.UPSERT.name().toLowerCase(Locale.ROOT)
+        );
+        props.put(OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG, "false");
+        connect.configureConnector(CONNECTOR_NAME, props);
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+        writeRecords(3);
+
+        waitForRecords(TOPIC_NAME, 3);
+
+        final var messages = new ArrayList<Pair<String, Map<String, Object>>>(3);
+        for (final var hit : search(TOPIC_NAME)) {
+            final var d = hit.getSourceAsMap();
+            messages.add(Pair.of(hit.getId(), hit.getSourceAsMap()));
+        }
+
+        for (var i = 0; i < messages.size(); i++) {
+            final var m = messages.get(i);
+            m.getRight().put("another_key", "another_value_" + i);
+            connect.kafka().produce(
+                    TOPIC_NAME,
+                    m.getLeft(),
+                    objectMapper.writeValueAsString(m.getRight())
+            );
+        }
+
+        connect.kafka().produce(
+                TOPIC_NAME,
+                String.valueOf(11),
+                String.format("{\"doc_num\":%d}", 11)
+        );
+        connect.kafka().produce(
+                TOPIC_NAME,
+                String.valueOf(12),
+                String.format("{\"doc_num\":%d}", 12)
+        );
+
+        waitForRecords(TOPIC_NAME, 5);
+
+        final var foundDocs = new HashMap<Integer, Map<String, Object>>();
+
+        for (final var hit : search(TOPIC_NAME)) {
+            final var id = Integer.valueOf(hit.getId());
+            foundDocs.put(id, hit.getSourceAsMap());
+        }
+
+        assertIterableEquals(
+                List.of(0, 1, 2, 11, 12),
+                foundDocs.keySet().stream().sorted().collect(Collectors.toList())
+        );
+
+        for (var i = 0; i < 3; i++) {
+            assertEquals(i, foundDocs.get(i).get("doc_num"));
+            assertEquals("another_value_" + i, foundDocs.get(i).get("another_key"));
+        }
+
+        assertEquals(11, foundDocs.get(11).get("doc_num"));
+        assertFalse(foundDocs.get(11).containsKey("another_key"));
+        assertEquals(12, foundDocs.get(12).get("doc_num"));
+        assertFalse(foundDocs.get(12).containsKey("another_key"));
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/opensearch/IndexWriteMethod.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/IndexWriteMethod.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+public enum IndexWriteMethod {
+
+    INSERT,
+    UPSERT;
+
+    public static String possibleValues() {
+        return Arrays.stream(IndexWriteMethod.values())
+                .map(IndexWriteMethod::name)
+                .map(s -> String.format("``%s``", s.toLowerCase(Locale.ROOT)))
+                .collect(Collectors.joining(", "));
+    }
+
+    public static final ConfigDef.Validator VALIDATOR = new ConfigDef.Validator() {
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            try {
+                IndexWriteMethod.valueOf(((String) value).toUpperCase(Locale.ROOT));
+            } catch (final IllegalArgumentException e) {
+                throw new ConfigException(name, value, "Index write method must be one of: "
+                        + IndexWriteMethod.possibleValues());
+            }
+        }
+
+        @Override
+        public String toString() {
+            return IndexWriteMethod.possibleValues();
+        }
+    };
+
+}

--- a/src/main/java/io/aiven/kafka/connect/opensearch/RequestBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/RequestBuilder.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2023 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.index.VersionType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_FIELD_DEFAULT;
+
+@FunctionalInterface
+public interface RequestBuilder {
+
+    Logger LOGGER = LoggerFactory.getLogger(RequestBuilder.class);
+
+    ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @FunctionalInterface
+    interface SetOpenSearchSinkConnectorConfig {
+        SetIndexName withConfig(final OpensearchSinkConnectorConfig config);
+    }
+
+    @FunctionalInterface
+    interface SetIndexName {
+        SetSinkRecord withIndex(final String index);
+    }
+
+    @FunctionalInterface
+    interface SetSinkRecord {
+        SetPayload withSinkRecord(final SinkRecord record);
+    }
+
+    @FunctionalInterface
+    @Deprecated(since = "2.1.0")
+    interface SetPayload {
+        @Deprecated(since = "2.1.0")
+        RequestBuilder withPayload(final String payload);
+    }
+
+
+    DocWriteRequest<?> build();
+
+    static SetOpenSearchSinkConnectorConfig builder() {
+        return config -> index -> record -> payload -> () -> {
+            final var documentIDStrategy = config.documentIdStrategy(record.topic());
+            final var documentId = documentIDStrategy.documentId(record);
+            if (Objects.isNull(record.value())) {
+                final var deleteRequest =
+                        new DeleteRequest()
+                                .id(documentId)
+                                .index(index);
+                return config.dataStreamEnabled()
+                        ? deleteRequest
+                        : addVersionIfAny(documentIDStrategy, record, deleteRequest);
+            }
+            if (config.indexWriteMethod() == IndexWriteMethod.UPSERT) {
+                return new UpdateRequest()
+                        .id(documentId)
+                        .index(index)
+                        .doc(payload, XContentType.JSON)
+                        .upsert(payload, XContentType.JSON)
+                        .docAsUpsert(true)
+                        .retryOnConflict(Math.min(config.maxInFlightRequests(), 3));
+            } else {
+                final var indexRequest =
+                        new IndexRequest()
+                                .id(documentId)
+                                .index(index);
+                if (config.dataStreamEnabled()) {
+                    return indexRequest
+                            .opType(DocWriteRequest.OpType.CREATE)
+                            .source(addTimestampToPayload(config, record, payload), XContentType.JSON);
+                } else {
+                    return addVersionIfAny(
+                            documentIDStrategy,
+                            record,
+                            indexRequest
+                                    .opType(DocWriteRequest.OpType.INDEX)
+                                    .source(payload, XContentType.JSON)
+                    );
+                }
+            }
+        };
+    }
+
+    private static DocWriteRequest<?> addVersionIfAny(final DocumentIDStrategy documentIDStrategy,
+                                                      final SinkRecord record,
+                                                      final DocWriteRequest<?> request) {
+        if (documentIDStrategy == DocumentIDStrategy.RECORD_KEY) {
+            request.versionType(VersionType.EXTERNAL);
+            request.version(record.kafkaOffset());
+        }
+        return request;
+    }
+
+    private static String addTimestampToPayload(final OpensearchSinkConnectorConfig config,
+                                                final SinkRecord record,
+                                                final String payload) {
+        if (DATA_STREAM_TIMESTAMP_FIELD_DEFAULT.equals(config.dataStreamTimestampField())) {
+            try {
+                final var json = OBJECT_MAPPER.readTree(payload);
+                if (!json.isObject()) {
+                    throw new DataException(
+                            "JSON payload is a type of "
+                                    + json.getNodeType()
+                                    + ". Required is JSON Object.");
+                }
+                final var rootObject = (ObjectNode) json;
+                if (!rootObject.has(DATA_STREAM_TIMESTAMP_FIELD_DEFAULT)) {
+                    if (Objects.isNull(record.timestamp())) {
+                        throw new DataException("Record timestamp hasn't been set");
+                    }
+                    rootObject.put(DATA_STREAM_TIMESTAMP_FIELD_DEFAULT, record.timestamp());
+                }
+                return OBJECT_MAPPER.writeValueAsString(json);
+            } catch (final IOException e) {
+                throw new DataException("Could not parse payload", e);
+            }
+        } else {
+            return payload;
+        }
+    }
+
+}

--- a/src/test/java/io/aiven/kafka/connect/opensearch/RequestBuilderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/RequestBuilderTest.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2023 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Map;
+
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.index.VersionType;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RequestBuilderTest {
+
+    private static final String KEY = "key";
+
+    private static final String TOPIC = "topic";
+
+    private static final int PARTITION = 5;
+
+    private static final long OFFSET = 15;
+
+    private static final String INDEX = "index";
+
+    private static final String VALUE = "value";
+
+    @Test
+    public void requestWithDocumentIdStrategyNone() throws Exception {
+        final var config = new OpensearchSinkConnectorConfig(
+                Map.of(
+                        OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost",
+                        OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG, "true",
+                        OpensearchSinkConnectorConfig.KEY_IGNORE_ID_STRATEGY_CONFIG,
+                        DocumentIDStrategy.NONE.toString()
+                )
+        );
+        final var deleteRequest =
+                RequestBuilder.builder()
+                        .withConfig(config)
+                        .withIndex(INDEX)
+                        .withSinkRecord(createSinkRecord(null))
+                        .withPayload("some_payload")
+                        .build();
+
+        assertTrue(deleteRequest instanceof DeleteRequest);
+        assertNull(deleteRequest.id(), deleteRequest.id());
+        assertEquals(INDEX, deleteRequest.index(), deleteRequest.index());
+        assertEquals(VersionType.INTERNAL, deleteRequest.versionType());
+
+
+        final var indexRequest =
+                RequestBuilder.builder()
+                        .withConfig(config)
+                        .withIndex(INDEX)
+                        .withSinkRecord(createSinkRecord(VALUE))
+                        .withPayload("some_payload")
+                        .build();
+        assertTrue(indexRequest instanceof IndexRequest);
+        assertNull(indexRequest.id(), indexRequest.id());
+        assertEquals(VersionType.INTERNAL, indexRequest.versionType());
+        assertEquals(
+                "some_payload",
+                readPayload(((IndexRequest) indexRequest).source(), "some_payload".length())
+        );
+
+
+    }
+
+    @Test
+    public void requestWithDocumentIdStrategyTopicPartitionOffset() throws Exception {
+        final var config = new OpensearchSinkConnectorConfig(
+                Map.of(
+                        OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost",
+                        OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG, "true",
+                        OpensearchSinkConnectorConfig.KEY_IGNORE_ID_STRATEGY_CONFIG,
+                        DocumentIDStrategy.TOPIC_PARTITION_OFFSET.toString()
+                )
+        );
+        final var deleteRequest =
+                RequestBuilder.builder()
+                        .withConfig(config)
+                        .withIndex(INDEX)
+                        .withSinkRecord(createSinkRecord(null))
+                        .withPayload("some_payload")
+                        .build();
+
+        assertTrue(deleteRequest instanceof DeleteRequest);
+        assertEquals(
+                String.format("%s+%s+%s", TOPIC, PARTITION, OFFSET),
+                deleteRequest.id(),
+                deleteRequest.id()
+        );
+        assertEquals(VersionType.INTERNAL, deleteRequest.versionType());
+
+        final var indexRequest =
+                RequestBuilder.builder()
+                        .withConfig(config)
+                        .withIndex(INDEX)
+                        .withSinkRecord(createSinkRecord(VALUE))
+                        .withPayload("some_payload_2")
+                        .build();
+
+        assertTrue(indexRequest instanceof IndexRequest);
+        assertEquals(
+                String.format("%s+%s+%s", TOPIC, PARTITION, OFFSET),
+                deleteRequest.id(),
+                deleteRequest.id()
+        );
+        assertEquals(VersionType.INTERNAL, deleteRequest.versionType());
+        assertEquals(DocWriteRequest.OpType.INDEX, indexRequest.opType());
+        assertEquals(
+                "some_payload_2",
+                readPayload(((IndexRequest) indexRequest).source(), "some_payload_2".length())
+        );
+    }
+
+    @Test
+    public void requestWithDocumentIdStrategyRecordKey() throws Exception {
+        final var config = new OpensearchSinkConnectorConfig(
+                Map.of(
+                        OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost",
+                        OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG, "true",
+                        OpensearchSinkConnectorConfig.KEY_IGNORE_ID_STRATEGY_CONFIG,
+                        DocumentIDStrategy.RECORD_KEY.toString()
+                )
+        );
+
+        final var deleteRequest =
+                RequestBuilder.builder()
+                        .withConfig(config)
+                        .withIndex(INDEX)
+                        .withSinkRecord(createSinkRecord(null))
+                        .withPayload("some_payload")
+                        .build();
+        assertTrue(deleteRequest instanceof DeleteRequest);
+        assertEquals(KEY, deleteRequest.id());
+        assertEquals(VersionType.EXTERNAL, deleteRequest.versionType());
+        assertEquals(OFFSET, deleteRequest.version());
+
+        final var indexRequest =
+                RequestBuilder.builder()
+                        .withConfig(config)
+                        .withIndex(INDEX)
+                        .withSinkRecord(createSinkRecord(VALUE))
+                        .withPayload("some_payload")
+                        .build();
+        assertTrue(indexRequest instanceof IndexRequest);
+        assertEquals(KEY, indexRequest.id());
+        assertEquals(DocWriteRequest.OpType.INDEX, indexRequest.opType());
+        assertEquals(VersionType.EXTERNAL, indexRequest.versionType());
+        assertEquals(OFFSET, indexRequest.version());
+        assertEquals(
+                "some_payload",
+                readPayload(((IndexRequest) indexRequest).source(), "some_payload".length())
+        );
+    }
+
+    @Test
+    void testUpsertRequest() throws Exception {
+        final var config = new OpensearchSinkConnectorConfig(
+                Map.of(
+                        OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost",
+                        OpensearchSinkConnectorConfig.INDEX_WRITE_METHOD,
+                            IndexWriteMethod.UPSERT.name().toLowerCase(Locale.ROOT)
+//                        OpensearchSinkConnectorConfig.KEY_IGNORE_CONFIG, "false"
+                )
+        );
+
+        final var upsertRequest =
+                RequestBuilder.builder()
+                        .withConfig(config)
+                        .withIndex(INDEX)
+                        .withSinkRecord(createSinkRecord("aaa"))
+                        .withPayload("aaa")
+                        .build();
+
+        assertTrue(upsertRequest instanceof UpdateRequest);
+        assertEquals(KEY, upsertRequest.id());
+
+        final var updateRequest = (UpdateRequest) upsertRequest;
+        assertTrue(updateRequest.docAsUpsert());
+        assertEquals(3, updateRequest.retryOnConflict());
+        assertEquals("aaa", readPayload(updateRequest.doc().source(), "aaa".length()));
+        assertEquals("aaa", readPayload(updateRequest.upsertRequest().source(), "aaa".length()));
+    }
+
+    @Test
+    void dataStreamRequest() throws Exception {
+        final var objectMapper = RequestBuilder.OBJECT_MAPPER;
+        final var config = new OpensearchSinkConnectorConfig(
+                Map.of(
+                        OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost",
+                        OpensearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true"
+                )
+        );
+
+        final var deleteRequest =
+                RequestBuilder.builder()
+                        .withConfig(config)
+                        .withIndex(INDEX)
+                        .withSinkRecord(createSinkRecord(null))
+                        .withPayload("aaaa")
+                        .build();
+
+        assertTrue(deleteRequest instanceof DeleteRequest);
+        assertEquals(VersionType.INTERNAL, deleteRequest.versionType());
+
+        final var payloadWithoutTimestamp =
+                objectMapper.writeValueAsString(
+                        objectMapper.createObjectNode()
+                                .put("a", "b")
+                                .put("c", "d")
+                                .put(OpensearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_FIELD_DEFAULT, "12345")
+                );
+
+        final var dataStreamRequest =
+                RequestBuilder.builder()
+                        .withConfig(config)
+                        .withIndex(INDEX)
+                        .withSinkRecord(createSinkRecord(VALUE))
+                        .withPayload(payloadWithoutTimestamp)
+                        .build();
+        assertTrue(dataStreamRequest instanceof IndexRequest);
+        assertEquals(DocWriteRequest.OpType.CREATE, dataStreamRequest.opType());
+        final var requestPayload = objectMapper.readValue(
+                readPayload(
+                        ((IndexRequest) dataStreamRequest).source(),
+                        payloadWithoutTimestamp.length()
+                ),
+                new TypeReference<Map<String, String>>() {}
+        );
+        assertEquals("12345", requestPayload.get("@timestamp"));
+    }
+
+    @Test
+    void dataStreamRequestWithCustomTimestamp() throws Exception {
+        final var objectMapper = RequestBuilder.OBJECT_MAPPER;
+        final var config = new OpensearchSinkConnectorConfig(
+                Map.of(
+                        OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost",
+                        OpensearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                        OpensearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_FIELD, "t"
+                )
+        );
+
+        final var payloadWithoutTimestamp =
+                objectMapper.writeValueAsString(
+                        objectMapper.createObjectNode()
+                                .put("a", "b")
+                                .put("c", "d")
+                                .put("t", "12345")
+                );
+
+        final var dataStreamRequest =
+                RequestBuilder.builder()
+                        .withConfig(config)
+                        .withIndex(INDEX)
+                        .withSinkRecord(createSinkRecord(VALUE))
+                        .withPayload(payloadWithoutTimestamp)
+                        .build();
+        assertTrue(dataStreamRequest instanceof IndexRequest);
+        assertEquals(DocWriteRequest.OpType.CREATE, dataStreamRequest.opType());
+        final var requestPayload = objectMapper.readValue(
+                readPayload(
+                        ((IndexRequest) dataStreamRequest).source(),
+                        payloadWithoutTimestamp.length()
+                ),
+                new TypeReference<Map<String, String>>() {}
+        );
+        assertEquals("12345", requestPayload.get("t"));
+    }
+
+    @Test
+    void dataStreamRequestWithEmptyTimestamp() throws Exception {
+        final var objectMapper = RequestBuilder.OBJECT_MAPPER;
+        final var config = new OpensearchSinkConnectorConfig(
+                Map.of(
+                        OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost",
+                        OpensearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true"
+                )
+        );
+
+        final var payloadWithoutTimestamp =
+                objectMapper.writeValueAsString(
+                        objectMapper.createObjectNode()
+                                .put("a", "b")
+                                .put("c", "d")
+                );
+
+        final var dataStreamRequest =
+                RequestBuilder.builder()
+                        .withConfig(config)
+                        .withIndex(INDEX)
+                        .withSinkRecord(createSinkRecord(VALUE))
+                        .withPayload(payloadWithoutTimestamp)
+                        .build();
+        assertTrue(dataStreamRequest instanceof IndexRequest);
+        assertEquals(DocWriteRequest.OpType.CREATE, dataStreamRequest.opType());
+        final var requestPayload = objectMapper.readValue(
+                readPayload(
+                        ((IndexRequest) dataStreamRequest).source(),
+                        payloadWithoutTimestamp.length()
+                ),
+                new TypeReference<Map<String, String>>() {}
+        );
+        assertNotNull(requestPayload.get(OpensearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_FIELD_DEFAULT));
+    }
+
+    SinkRecord createSinkRecord(final Object value) {
+        return new SinkRecord(
+                TOPIC,
+                PARTITION,
+                Schema.STRING_SCHEMA,
+                KEY,
+                SchemaBuilder
+                        .struct()
+                        .name("struct")
+                        .field("string", Schema.STRING_SCHEMA)
+                        .build(),
+                value,
+                OFFSET,
+                System.currentTimeMillis(), TimestampType.CREATE_TIME
+        );
+    }
+
+    String readPayload(final BytesReference source, final int length) throws IOException {
+        try (final var buffer = new ByteArrayOutputStream(length)) {
+            source.writeTo(buffer);
+            return buffer.toString(StandardCharsets.UTF_8);
+        }
+    }
+
+}


### PR DESCRIPTION
The aim of this PR is to add support for upsert of documents in the index.

For that a new additional config property was added:
`index.write.method` - which takes 2 possible values: `insert` and `upsert`. The default is `insert` which is the current default behave. 

Signed-off-by: Andrey Pleskach <ples@aiven.io>