### PR TITLE
Use slf4j 2.x instead 1.7.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,10 +119,10 @@ publishing {
 
 ext {
     kafkaVersion = "2.8.1"
-    slf4jVersion = "1.7.36"
+    slf4jVersion = "2.0.7"
     openSearchVersion = "2.7.0"
 
-    testcontainersVersion = "1.18.3"
+    testcontainersVersion = "1.18.0"
     confluentPlatformVersion = "4.1.4"
 }
 
@@ -168,9 +168,9 @@ dependencies {
 
     testImplementation "org.apache.kafka:connect-api:$kafkaVersion"
     testImplementation "org.apache.kafka:connect-json:$kafkaVersion"
-    testImplementation "com.fasterxml.jackson.core:jackson-core:2.15.2"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.15.2"
-    testImplementation "com.fasterxml.jackson.core:jackson-annotations:2.15.2"
+    testImplementation "com.fasterxml.jackson.core:jackson-core:2.15.0"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.14.2"
+    testImplementation "com.fasterxml.jackson.core:jackson-annotations:2.14.2"
     testRuntimeOnly "org.slf4j:slf4j-log4j12:$slf4jVersion"
 
     integrationTestImplementation "org.testcontainers:junit-jupiter:$testcontainersVersion"


### PR DESCRIPTION
Switched slf4j to version 2.x since 1.7.x is not supported anymore