### PR TITLE
Draft: Create .tar.gz archive in releases

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -39,14 +39,17 @@ jobs:
 
       - name: Build
         run: |
-          ./gradlew distTar distZip
+          ./gradlew distTar distTarGz distZip
 
           export tar_file=$(ls ./build/distributions/ | grep tar)
+          export tar_gz_file=$(ls ./build/distributions/ | grep tar.gz)
           export zip_file=$(ls ./build/distributions/ | grep zip)
           echo tar_file=${tar_file} >> $GITHUB_ENV
+          echo tar_gz_file=${tar_gz_file} >> $GITHUB_ENV
           echo zip_file=${zip_file} >> $GITHUB_ENV
 
           echo tar_path=`realpath ./build/distributions/${tar_file}` >> $GITHUB_ENV
+          echo tar_gz_path=`realpath ./build/distributions/${tar_gz_file}` >> $GITHUB_ENV
           echo zip_path=`realpath ./build/distributions/${zip_file}` >> $GITHUB_ENV
 
       - name: Create tag
@@ -79,6 +82,16 @@ jobs:
           asset_path: ${{ env.tar_path }}
           asset_name: ${{ env.tar_file }}
           asset_content_type: application/tar
+
+      - name: Upload tar gzip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ env.tar_gz_path }}
+          asset_name: ${{ env.tar_gz_file }}
+          asset_content_type: application/gzip
 
       - name: Upload zip
         uses: actions/upload-release-asset@v1

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The code was forked and all classes were renamed.
 
 ## How to install
 
-1. Connector plugins are packaged in zip/tar format to be released
+1. Connector plugins are packaged in zip/tar/tar.gz format to be released
 2. Users download plugins from GitHub releases or build binaries from source
 3. Users place connector plugins on Connect worker instances and add them via configuration
 4. Start creating connectors using installed plugins


### PR DESCRIPTION
Required for running Strimzi Kafka Connect:

https://github.com/strimzi/strimzi-kafka-operator/blob/9b96cb8a30fe20c8fbc98c5b47a1310e33d15412/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaConnectDockerfile.java#L376