### PR TITLE
Extend OS PR build matrix

### DIFF
--- a/.github/workflows/main_and_pr_workflow.yml
+++ b/.github/workflows/main_and_pr_workflow.yml
@@ -9,12 +9,11 @@ jobs:
     strategy:
       matrix:
         entry:
-          - { opensearch-version: 1.3.6, java-version: 11 }
-          - { opensearch-version: 1.3.6, java-version: 17 }
-          - { opensearch-version: 1.3.6, java-version: 19 }
-          - { opensearch-version: 2.3.0, java-version: 11 }
-          - { opensearch-version: 2.3.0, java-version: 17 }
-          - { opensearch-version: 2.3.0, java-version: 19 }
+          - { opensearch-version: 1.3.13, java-version: 11 }
+          - { opensearch-version: 1.3.13, java-version: 17 }
+          - { opensearch-version: 2.11.0, java-version: 11 }
+          - { opensearch-version: 2.11.0, java-version: 17 }
+          - { opensearch-version: 2.11.0, java-version: 21 }
         runs-on: [ubuntu-latest]
     name: Check on ${{ matrix.runs-on }} (JDK-${{ matrix.entry.java-version }}, OpenSearch ${{ matrix.entry.opensearch-version }})
     runs-on: ${{ matrix.runs-on }}
@@ -33,7 +32,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [ 11, 17, 19 ]
+        java-version: [ 11, 17, 21 ]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
     name: Build on ${{ matrix.runs-on }} with jdk ${{ matrix.java-version }}
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
Changes:
- Switched to latest OS versions 1.3.13 and 2.11
- Extended build matrix to support JDK 21