### PR TITLE
Change Request:  Make Retriable Failed to send bulk request from batch error as warning

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java
@@ -415,7 +415,7 @@ public class BulkProcessor {
                     }
                     return response;
                 } catch (final IOException e) {
-                    LOGGER.error("Failed to send bulk request from batch {} of {} records", batchId, batch.size(), e);
+                    LOGGER.warn("Failed to send bulk request from batch {} of {} records", batchId, batch.size(), e);
                     throw new RetriableError(e);
                 }
             }, maxRetries, retryBackoffMs, RetriableError.class);


### PR DESCRIPTION
This is a change to the fix made under https://github.com/Aiven-Open/opensearch-connector-for-apache-kafka/issues/227 , https://github.com/Aiven-Open/opensearch-connector-for-apache-kafka/issues/179 . 
Now with connector version opensearch-connector-for-apache-kafka-3.1.1 . I get this error in logs but the connector keeps on working as expected because of the retry mechanism. But our log monitors alert us because these retries are logged as ERROR not WARN. Also i cannot skip ERROR/set log level to FATAL from `io.aiven.kafka.connect.opensearch.BulkProcessor` as a whole because of the non-retriable errors are also logged as error [example 1](https://github.com/Aiven-Open/opensearch-connector-for-apache-kafka/blob/main/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java#L125), [example 2](https://github.com/Aiven-Open/opensearch-connector-for-apache-kafka/blob/main/src/main/java/io/aiven/kafka/connect/opensearch/BulkProcessor.java#L452)  . So can we make it a warning instead?