### PR TITLE
Add support for routing

### DIFF
--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -275,6 +275,22 @@ Data Conversion
   * Valid Values: [ignore, warn, fail, report]
   * Importance: low
 
+``routing.type``
+  Specifies the routing type which connector uses when sending documents to OpenSearch. Available types: {none : No routing is added, key : The routing value is determined by the record’s key, value : The routing value is determined by the record's value}. If not specified, the default is ``none``.
+
+  * Type: string
+  * Default: none
+  * Valid Values: [none, key, value]
+  * Importance: low
+
+``routing.type.record.value.path``
+  Specifies the routing value which is determined by the record's value as JSON Pointer
+
+  * Type: string
+  * Default: null
+  * Valid Values: A valid JSON Pointer value (https://datatracker.ietf.org/doc/html/rfc6901)
+  * Importance: low
+
 Data Stream
 ^^^^^^^^^^^
 

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
@@ -114,8 +114,16 @@ public class AbstractKafkaConnectIT extends AbstractIT {
 
     void writeRecords(final int numRecords, String topicNameToWrite) {
         for (int i = 0; i < numRecords; i++) {
-            connect.kafka().produce(topicNameToWrite, String.valueOf(i), String.format("{\"doc_num\":%d}", i));
+            writeRecord(topicNameToWrite, String.valueOf(i), i);
         }
+    }
+
+    void writeRecord(final String topicNameToWrite, final String key, final int recordValue) {
+        writeRecord(topicNameToWrite, key, String.format("{\"doc_num\":%d}", recordValue));
+    }
+
+    void writeRecord(String topicNameToWrite, final String key, String value) {
+        connect.kafka().produce(topicNameToWrite, key, value);
     }
 
 }

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkRoutingConnectorIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkRoutingConnectorIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aiven.kafka.connect.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.indices.IndexSettings;
+import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OpenSearchSinkRoutingConnectorIT extends AbstractKafkaConnectIT {
+
+    static final String CONNECTOR_NAME = "os-sink-connector";
+
+    static final String TOPIC_NAME = "os-routing-topic";
+
+    static final String INDEX_TEMPLATE_NAME = "two_shards_template";
+
+    public OpenSearchSinkRoutingConnectorIT() {
+        super(TOPIC_NAME, CONNECTOR_NAME);
+    }
+
+    @BeforeEach
+    void createTemplate() throws Exception {
+        opensearchClient.indices()
+                .putIndexTemplate(PutIndexTemplateRequest.builder()
+                        .name(INDEX_TEMPLATE_NAME)
+                        .indexPatterns(List.of(TOPIC_NAME))
+                        .template(b -> b.settings(IndexSettings.builder().numberOfShards(2).build()))
+                        .build());
+    }
+
+    @AfterEach
+    void deleteTemplate() throws Exception {
+        opensearchClient.indices().deleteIndexTemplate(b -> b.name(INDEX_TEMPLATE_NAME));
+    }
+
+    @Test
+    public void testKeyRoutingConnector() throws Exception {
+        final var props = connectorProperties(TOPIC_NAME);
+        props.put(OpenSearchSinkConnectorConfig.ROUTING_TYPE, RoutingType.KEY.toString());
+        connect.configureConnector(CONNECTOR_NAME, props);
+
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+        for (var i = 0; i < 5; i++) {
+            writeRecord(TOPIC_NAME, "0", i);
+        }
+        for (var i = 0; i < 5; i++) {
+            writeRecord(TOPIC_NAME, "1", i + 5);
+        }
+
+        waitForRecords(TOPIC_NAME, 10);
+        assertRoutingRecords();
+    }
+
+    @Test
+    public void testValueRoutingConnector() throws Exception {
+        final var props = connectorProperties(TOPIC_NAME);
+        props.put(OpenSearchSinkConnectorConfig.ROUTING_TYPE, RoutingType.VALUE.toString());
+        props.put(OpenSearchSinkConnectorConfig.ROUTING_RECORD_VALUE_PATH, "/r");
+        connect.configureConnector(CONNECTOR_NAME, props);
+
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+        for (var i = 0; i < 5; i++) {
+            writeRecord(TOPIC_NAME, String.valueOf(i), String.format("{\"r\":0, \"doc_num\":%d}", i));
+        }
+        for (var i = 0; i < 5; i++) {
+            writeRecord(TOPIC_NAME, String.valueOf(i), String.format("{\"r\":1, \"doc_num\":%d}", i + 5));
+        }
+
+        waitForRecords(TOPIC_NAME, 10);
+        assertRoutingRecords();
+    }
+
+    void assertRoutingRecords() throws Exception {
+        var searchResults = opensearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME).routing("0")), Map.class)
+                .hits();
+        var counter = 0;
+        for (final var hit : searchResults.hits()) {
+            assertEquals("0", hit.routing());
+            assertEquals(String.valueOf(counter++), hit.source().get("doc_num").toString());
+        }
+
+        searchResults = opensearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME).routing("1")), Map.class)
+                .hits();
+        for (final var hit : searchResults.hits()) {
+            assertEquals("1", hit.routing());
+            assertEquals(String.valueOf(counter++), hit.source().get("doc_num").toString());
+        }
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorConfig.java
@@ -51,6 +51,7 @@ import org.apache.kafka.common.config.SslConfigs;
 
 import io.aiven.kafka.connect.opensearch.spi.ConfigDefContributor;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import org.apache.hc.core5.http.HttpHost;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -209,6 +210,15 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
     public final static String SSL_CONFIG_TRUST_ALL_CERTIFICATES = "trust.all.certificates";
     public final static String SSL_CONFIG_TRUST_ALL_CERTIFICATES_DOC = "Allow to trust all certificates. Default is false";
 
+    public final static String ROUTING_TYPE = "routing.type";
+    private static final String ROUTING_TYPE_DOC = "Specifies the routing type which connector uses when sending documents to OpenSearch. Available types: "
+            + RoutingType.describe() + ". " + "If not specified, the default is ``none``.";
+
+    public final static String ROUTING_RECORD_VALUE_PATH = "routing.type.record.value.path";
+    public final static String ROUTING_RECORD_VALUE_PATH_DOC = "Specifies the routing value which is determined by the record's value as JSON Pointer";
+
+    private JsonPointer routingRecordValueJsonPointer;
+
     protected static ConfigDef baseConfigDef() {
         final ConfigDef configDef = new ConfigDef();
         addConnectorConfigs(configDef);
@@ -345,7 +355,27 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
                 .define(BEHAVIOR_ON_VERSION_CONFLICT_CONFIG, Type.STRING, BehaviorOnVersionConflict.DEFAULT.toString(),
                         BehaviorOnVersionConflict.VALIDATOR, Importance.LOW, BEHAVIOR_ON_VERSION_CONFLICT_DOC,
                         DATA_CONVERSION_GROUP_NAME, ++order, Width.SHORT,
-                        "Behavior on document's version conflict (optimistic locking)");
+                        "Behavior on document's version conflict (optimistic locking)")
+                .define(ROUTING_TYPE, Type.STRING, RoutingType.NONE.toString(), RoutingType.VALIDATOR, Importance.LOW,
+                        ROUTING_TYPE_DOC, DATA_CONVERSION_GROUP_NAME, ++order, Width.LONG, "Routing type")
+                .define(ROUTING_RECORD_VALUE_PATH, Type.STRING, null, new ConfigDef.Validator() {
+                    @Override
+                    public void ensureValid(String name, Object value) {
+                        if (value instanceof String s) {
+                            try {
+                                JsonPointer.compile(s);
+                            } catch (final IllegalArgumentException e) {
+                                throw new ConfigException(e.getMessage());
+                            }
+                        }
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "A valid JSON Pointer value (https://datatracker.ietf.org/doc/html/rfc6901)";
+                    }
+                }, Importance.LOW, ROUTING_RECORD_VALUE_PATH_DOC, DATA_CONVERSION_GROUP_NAME, ++order, Width.LONG,
+                        "The routing value is determined by the record's value");
     }
 
     private static void addDataStreamConfig(final ConfigDef configDef) {
@@ -387,6 +417,18 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
             throw new ConfigException(KEY_IGNORE_ID_STRATEGY_CONFIG, documentIdStrategy().toString(),
                     String.format("%s is not supported for index upsert. Supported is: %s",
                             documentIdStrategy().toString(), DocumentIDStrategy.RECORD_KEY));
+        }
+        if (routingType() == RoutingType.VALUE) {
+            if (routingRecordValuePath() == null) {
+                throw new ConfigException(
+                        String.format("The '%s' setting must be configured when using the '%s' routing type",
+                                ROUTING_RECORD_VALUE_PATH, RoutingType.VALUE.toString()));
+            }
+            if (routingRecordValuePath() != null && behaviorOnNullValues() == BehaviorOnNullValues.DELETE) {
+                throw new ConfigException(String.format("The '%s' can't be used together with '%s' set to '%s'",
+                        ROUTING_RECORD_VALUE_PATH, BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                        BehaviorOnNullValues.DELETE.toString()));
+            }
         }
     }
 
@@ -613,6 +655,19 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
 
     public boolean trustAllCertificates() {
         return getBoolean(SSL_CONFIG_PREFIX + SSL_CONFIG_TRUST_ALL_CERTIFICATES);
+    }
+
+    public RoutingType routingType() {
+        return RoutingType.fromString(getString(ROUTING_TYPE));
+    }
+
+    public JsonPointer routingRecordValuePath() {
+        final var p = getString(ROUTING_RECORD_VALUE_PATH);
+        if (p == null)
+            return null;
+        if (routingRecordValueJsonPointer == null)
+            routingRecordValueJsonPointer = JsonPointer.compile(p);
+        return routingRecordValueJsonPointer;
     }
 
     public static void main(final String[] args) {

--- a/src/main/java/io/aiven/kafka/connect/opensearch/RoutingType.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/RoutingType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2026 Aiven Oy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,60 +17,29 @@ package io.aiven.kafka.connect.opensearch;
 
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.connect.sink.SinkRecord;
 
-public enum DocumentIDStrategy {
+public enum RoutingType {
 
-    NONE("none", "No Doc ID is added", record -> null),
+    NONE("none", "No routing is added"),
 
-    RECORD_KEY("record.key", "Generated from the record's key", Utils::convertKey),
+    KEY("key", "The routing value is determined by the record’s key"),
 
-    TOPIC_PARTITION_OFFSET("topic.partition.offset", "Generated as record's ``topic+partition+offset``",
-            record -> String.format("%s+%s+%s", record.topic(), record.kafkaPartition(), record.kafkaOffset()));
+    VALUE("value", "The routing value is determined by the record's value");
 
     private final String name;
 
     private final String description;
 
-    private final Function<SinkRecord, String> docIdGenerator;
-
-    private DocumentIDStrategy(final String name, final String description,
-            final Function<SinkRecord, String> docIdGenerator) {
+    private RoutingType(final String name, final String description) {
         this.name = name.toLowerCase(Locale.ROOT);
         this.description = description;
-        this.docIdGenerator = docIdGenerator;
-    }
-
-    public String documentId(final SinkRecord record) {
-        return docIdGenerator.apply(record);
-    }
-
-    @Override
-    public String toString() {
-        return name;
-    }
-
-    public static DocumentIDStrategy fromString(final String name) {
-        for (final DocumentIDStrategy strategy : DocumentIDStrategy.values()) {
-            if (strategy.name.equalsIgnoreCase(name)) {
-                return strategy;
-            }
-        }
-        throw new IllegalArgumentException("Unknown Document ID Strategy " + name);
-    }
-
-    public static String describe() {
-        return Arrays.stream(values())
-                .map(v -> v.toString() + " : " + v.description)
-                .collect(Collectors.joining(", ", "{", "}"));
     }
 
     public static final ConfigDef.Validator VALIDATOR = new ConfigDef.Validator() {
-        private final String[] names = Arrays.stream(values()).map(v -> v.toString()).toArray(String[]::new);
+        private final String[] names = Arrays.stream(values()).map(Enum::toString).toArray(String[]::new);
         private final ConfigDef.ValidString validator = ConfigDef.ValidString.in(names);
 
         @Override
@@ -89,4 +58,25 @@ public enum DocumentIDStrategy {
             return validator.toString();
         }
     };
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    public static String describe() {
+        return Arrays.stream(values())
+                .map(v -> v.toString() + " : " + v.description)
+                .collect(Collectors.joining(", ", "{", "}"));
+    }
+
+    public static RoutingType fromString(final String name) {
+        for (final RoutingType routingType : RoutingType.values()) {
+            if (routingType.name.equalsIgnoreCase(name)) {
+                return routingType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown routing type " + name);
+    }
+
 }

--- a/src/main/java/io/aiven/kafka/connect/opensearch/Utils.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/Utils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public class Utils {
+
+    private Utils() {
+    }
+
+    public static String convertKey(final SinkRecord record) {
+        return convertKey(record.keySchema(), record.key());
+    }
+
+    public static String convertKey(final Schema keySchema, final Object key) {
+        if (key == null) {
+            throw new DataException("Key is used as document id and can not be null.");
+        }
+
+        final Schema.Type schemaType;
+        if (keySchema == null) {
+            schemaType = ConnectSchema.schemaType(key.getClass());
+            if (schemaType == null) {
+                throw new DataException(
+                        String.format("Java class %s does not have corresponding schema type.", key.getClass()));
+            }
+        } else {
+            schemaType = keySchema.type();
+        }
+
+        switch (schemaType) {
+            case INT8 :
+            case INT16 :
+            case INT32 :
+            case INT64 :
+            case STRING :
+                return String.valueOf(key);
+            default :
+                throw new DataException(String.format("%s type is not supported. Supported are: %s", schemaType.name(),
+                        List.of(Schema.INT8_SCHEMA, Schema.INT16_SCHEMA, Schema.INT32_SCHEMA, Schema.INT64_SCHEMA,
+                                Schema.STRING_SCHEMA)));
+        }
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/opensearch/request/BulkOperationBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/request/BulkOperationBuilder.java
@@ -17,6 +17,8 @@ package io.aiven.kafka.connect.opensearch.request;
 
 import static java.util.Objects.isNull;
 
+import java.io.IOException;
+
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
@@ -33,7 +35,9 @@ import io.aiven.kafka.connect.opensearch.DocumentIDStrategy;
 import io.aiven.kafka.connect.opensearch.IndexWriteMethod;
 import io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig;
 import io.aiven.kafka.connect.opensearch.OpenSearchTaskHandler;
+import io.aiven.kafka.connect.opensearch.Utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +46,8 @@ public final class BulkOperationBuilder {
     private final OpenSearchSinkConnectorConfig config;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchTaskHandler.class);
+
+    private final ObjectMapper mapper = new ObjectMapper();
 
     public BulkOperationBuilder(final OpenSearchSinkConnectorConfig config) {
         this.config = config;
@@ -83,28 +89,34 @@ public final class BulkOperationBuilder {
         final var documentId = documentIDStrategy.documentId(record);
         final BulkOperation bulkOperation;
         if (isNull(record.value())) {
-            final var deleteOperationBuilder = new DeleteOperation.Builder().id(documentId).index(indexName);
+            final var routing = routingValue(record, null);
+            final var deleteOperationBuilder = new DeleteOperation.Builder().id(documentId)
+                    .routing(routing)
+                    .index(indexName);
             if (!config.dataStreamEnabled()) {
                 addVersionIfAny(deleteOperationBuilder, documentIDStrategy, record);
             }
             bulkOperation = BulkOperation.of(b -> b.delete(deleteOperationBuilder.build()));
         } else {
             final var payload = DocumentPayload.buildPayload(config, record);
+            final var routing = routingValue(record, payload);
             final var binaryData = BinaryData.of(payload, ContentType.APPLICATION_JSON);
             if (config.indexWriteMethod() == IndexWriteMethod.UPSERT) {
                 bulkOperation = BulkOperation.of(b -> b.update(u -> u.id(documentId)
+                        .index(indexName)
+                        .routing(routing)
                         .document(binaryData)
                         .upsert(binaryData)
                         .docAsUpsert(true)
-                        .index(indexName)
                         .retryOnConflict(Math.min(config.maxInFlightRequests(), 3))));
             } else {
                 if (config.dataStreamEnabled()) {
-                    bulkOperation = BulkOperation
-                            .of(b -> b.create(c -> c.id(documentId).index(indexName).document(binaryData)));
+                    bulkOperation = BulkOperation.of(b -> b
+                            .create(c -> c.id(documentId).index(indexName).routing(routing).document(binaryData)));
                 } else {
                     final var indexOperationBuilder = new IndexOperation.Builder<>().id(documentId)
                             .index(indexName)
+                            .routing(routing)
                             .document(binaryData);
                     addVersionIfAny(indexOperationBuilder, documentIDStrategy, record);
                     bulkOperation = BulkOperation.of(b -> b.index(indexOperationBuilder.build()));
@@ -121,6 +133,35 @@ public final class BulkOperationBuilder {
             operationBuilder.versionType(VersionType.External);
         } else {
             operationBuilder.versionType(VersionType.Internal);
+        }
+    }
+
+    private String routingValue(final SinkRecord record, final byte[] payload) {
+        switch (config.routingType()) {
+            case KEY -> {
+                return Utils.convertKey(record);
+            }
+            case VALUE -> {
+                try {
+                    final var p = config.routingRecordValuePath();
+                    final var node = mapper.readTree(payload).at(p);
+                    if (node.isTextual() || node.isNumber()) {
+                        final var text = node.asText();
+                        if (isNull(text) || text.isEmpty()) {
+                            throw new DataException(String.format("Couldn't determine value for path: %s", p));
+                        }
+                        return text;
+                    }
+                    throw new DataException(String.format(
+                            "%s node type is not supported. Supported are: JSON string or JSON numeric values",
+                            node.getNodeType()));
+                } catch (IOException e) {
+                    throw new DataException(e);
+                }
+            }
+            default -> {
+                return null;
+            }
         }
     }
 

--- a/src/test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorConfigTest.java
@@ -31,6 +31,7 @@ import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_TYPE_CONF
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,6 +51,7 @@ import org.apache.kafka.common.config.SslConfigs;
 
 import io.aiven.kafka.connect.opensearch.spi.ConfigDefContributor;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -301,6 +303,67 @@ public class OpenSearchSinkConnectorConfigTest {
                 Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://l:9200",
                         OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true"));
         assertEquals("bbbbb", noDsPrefixConfig.topicToIndexNameConverter().apply("bbbbb"));
+    }
+
+    @Test
+    void testDefaultRoutingSettings() {
+        final var config = new OpenSearchSinkConnectorConfig(
+                Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://l:9200"));
+
+        assertEquals(RoutingType.NONE, config.routingType());
+        assertNull(config.routingRecordValuePath());
+    }
+
+    @Test
+    void testSetKeyRoutingSettings() {
+        final var config = new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                "http://l:9200", OpenSearchSinkConnectorConfig.ROUTING_TYPE, RoutingType.KEY.toString()));
+
+        assertEquals(RoutingType.KEY, config.routingType());
+        assertNull(config.routingRecordValuePath());
+    }
+
+    @Test
+    void testSetValueRoutingSettings() {
+        final var config = new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                "http://l:9200", OpenSearchSinkConnectorConfig.ROUTING_TYPE, RoutingType.VALUE.toString(),
+                OpenSearchSinkConnectorConfig.ROUTING_RECORD_VALUE_PATH, "/a/b/c"));
+
+        assertEquals(RoutingType.VALUE, config.routingType());
+        assertNotNull(config.routingRecordValuePath());
+        assertEquals(JsonPointer.compile("/a/b/c"), config.routingRecordValuePath());
+    }
+
+    @Test
+    void testThrowExceptionForWrongValueRoutingSettings() {
+        final var e = assertThrows(ConfigException.class,
+                () -> new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                        "http://l:9200", OpenSearchSinkConnectorConfig.ROUTING_TYPE, RoutingType.VALUE.toString())));
+        assertEquals(
+                "The 'routing.type.record.value.path' setting must be configured when using the 'value' routing type",
+                e.getMessage());
+    }
+
+    @Test
+    void testThrowExceptionForWrongRoutingJSONPointerValueSettings() {
+        final var e = assertThrows(ConfigException.class,
+                () -> new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                        "http://l:9200", OpenSearchSinkConnectorConfig.ROUTING_TYPE, RoutingType.VALUE.toString(),
+                        OpenSearchSinkConnectorConfig.ROUTING_RECORD_VALUE_PATH, "f\\g")));
+        assertEquals("Invalid input: JSON Pointer expression must start with '/': \"f\\g\"", e.getMessage());
+    }
+
+    @Test
+    void testThrowExceptionForWrongRoutingJSONPointerValueSettingsAndBehaviorOnNullValuesDelete() {
+        final var e = assertThrows(ConfigException.class,
+                () -> new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                        "http://l:9200", OpenSearchSinkConnectorConfig.ROUTING_TYPE, RoutingType.VALUE.toString(),
+                        OpenSearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                        BehaviorOnNullValues.DELETE.toString(), OpenSearchSinkConnectorConfig.ROUTING_RECORD_VALUE_PATH,
+                        "/f/g")));
+        assertEquals(
+                "The 'routing.type.record.value.path' can't be used together with 'behavior.on.null.values' set to 'delete'",
+                e.getMessage());
     }
 
 }


### PR DESCRIPTION
Added supported for [routing](https://docs.opensearch.org/latest/mappings/metadata-fields/routing/)

There 2 way  to determine routing:
- key based, when the routing value is determined by the record’s key
- value based, when the routing value is determined by the record's value as [JSON Pointer](https://datatracker.ietf.org/doc/html/rfc6901)
