### PR TITLE
Remove obsolete settings

### DIFF
--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -12,43 +12,6 @@ Connector
   * Valid Values: http://eshost1:9200, http://eshost2:9200
   * Importance: high
 
-``batch.size``
-  The number of records to process as a batch when writing to OpenSearch.
-
-  * Type: int
-  * Default: 2000
-  * Importance: medium
-
-``max.in.flight.requests``
-  The maximum number of indexing requests that can be in-flight to OpenSearch before blocking further requests.
-
-  * Type: int
-  * Default: 5
-  * Importance: medium
-
-``max.buffered.records``
-  The maximum number of records each task will buffer before blocking acceptance of more records. This config can be used to limit the memory usage for each task.
-
-  * Type: int
-  * Default: 20000
-  * Importance: low
-
-``linger.ms``
-  Linger time in milliseconds for batching.
-
-  Records that arrive in between request transmissions are batched into a single bulk indexing request, based on the ``batch.size`` configuration. Normally this only occurs under load when records arrive faster than they can be sent out. However it may be desirable to reduce the number of requests even under light load and benefit from bulk indexing. This setting helps accomplish that - when a pending batch is not full, rather than immediately sending it out the task will wait up to the given delay to allow other records to be added so that they can be batched into a single request.
-
-  * Type: long
-  * Default: 1
-  * Importance: low
-
-``flush.timeout.ms``
-  The timeout in milliseconds to use for periodic flushing, and when waiting for buffer space to be made available by completed requests as records are added. If this timeout is exceeded the task will fail.
-
-  * Type: long
-  * Default: 10000 (10 seconds)
-  * Importance: low
-
 ``max.retries``
   The maximum number of retries that are allowed for failed indexing requests. If the retry attempts are exhausted the task will fail.
 
@@ -75,6 +38,30 @@ Connector
 
   * Type: int
   * Default: 3000 (3 seconds)
+  * Importance: low
+
+Bulk settings
+^^^^^^^^^^^^^
+
+``bulk.max.size``
+  Sets when to flush a new bulk request based on the size in bytes of actions currently added. A request is sent once that size has been exceeded. Defaults to 5 megabytes. Can be set to -1 to disable it.
+
+  * Type: int
+  * Default: 5
+  * Importance: medium
+
+``bulk.max.operations.size``
+  Sets when to flush a new bulk request based on the number of operations currently added. Defaults to 1000. Can be set to -1 to disable it.
+
+  * Type: int
+  * Default: 1000
+  * Importance: medium
+
+``bulk.max.concurrent.requests``
+  Sets the number of concurrent requests allowed to be executed. A value of 1 means 1 request is allowed to be executed while accumulating new bulk requests. Defaults to 1.
+
+  * Type: int
+  * Default: 1
   * Importance: low
 
 TLS Configuration for HTTPS

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractKafkaConnectIT.java
@@ -15,8 +15,8 @@
  */
 package io.aiven.kafka.connect.opensearch;
 
+import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.BULK_MAX_OPERATIONS_SIZE;
 import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.KEY_IGNORE_CONFIG;
-import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.SCHEMA_IGNORE_CONFIG;
 import static org.apache.kafka.connect.json.JsonConverterConfig.SCHEMAS_ENABLE_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
@@ -107,7 +107,7 @@ public class AbstractKafkaConnectIT extends AbstractIT {
         props.put("value.converter." + SCHEMAS_ENABLE_CONFIG, "false");
         props.put(KEY_IGNORE_CONFIG, "true");
         props.put(SCHEMA_IGNORE_CONFIG, "true");
-        props.put(MAX_BUFFERED_RECORDS_CONFIG, "1");
+        props.put(BULK_MAX_OPERATIONS_SIZE, "1");
         props.put("offset.flush.timeout.ms", "1000");
         return props;
     }

--- a/src/main/java/io/aiven/kafka/connect/opensearch/HttpClientConfigCallback.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/HttpClientConfigCallback.java
@@ -68,7 +68,7 @@ public record HttpClientConfigCallback(
     }
 
     private PoolingAsyncClientConnectionManager createConnectionManager() {
-        final var maxPerRoute = Math.max(10, config.maxInFlightRequests() * 2);
+        final var maxPerRoute = Math.max(10, config.maxOperations() * 2);
         return PoolingAsyncClientConnectionManagerBuilder.create()
                 .setTlsStrategy(ClientTlsStrategyBuilder.create()
                         .setSslContext(sslContext(config))

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorConfig.java
@@ -69,27 +69,28 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
     public static final String CONNECTION_URL_CONFIG = "connection.url";
     private static final String CONNECTION_URL_DOC = "List of OpenSearch HTTP connection URLs e.g. ``http://eshost1:9200,"
             + "http://eshost2:9200``.";
-    public static final String BATCH_SIZE_CONFIG = "batch.size";
-    private static final String BATCH_SIZE_DOC = "The number of records to process as a batch when writing to OpenSearch.";
-    public static final String MAX_IN_FLIGHT_REQUESTS_CONFIG = "max.in.flight.requests";
-    private static final String MAX_IN_FLIGHT_REQUESTS_DOC = "The maximum number of indexing requests that can be in-flight to OpenSearch before "
-            + "blocking further requests.";
-    public static final String MAX_BUFFERED_RECORDS_CONFIG = "max.buffered.records";
-    private static final String MAX_BUFFERED_RECORDS_DOC = "The maximum number of records each task will buffer before blocking acceptance of more "
-            + "records. This config can be used to limit the memory usage for each task.";
-    public static final String LINGER_MS_CONFIG = "linger.ms";
-    private static final String LINGER_MS_DOC = "Linger time in milliseconds for batching.\n"
-            + "Records that arrive in between request transmissions are batched into a single bulk "
-            + "indexing request, based on the ``" + BATCH_SIZE_CONFIG + "`` configuration. Normally "
-            + "this only occurs under load when records arrive faster than they can be sent out. "
-            + "However it may be desirable to reduce the number of requests even under light load and "
-            + "benefit from bulk indexing. This setting helps accomplish that - when a pending batch is"
-            + " not full, rather than immediately sending it out the task will wait up to the given "
-            + "delay to allow other records to be added so that they can be batched into a single " + "request.";
-    public static final String FLUSH_TIMEOUT_MS_CONFIG = "flush.timeout.ms";
-    private static final String FLUSH_TIMEOUT_MS_DOC = "The timeout in milliseconds to use for periodic flushing, and when waiting for buffer "
-            + "space to be made available by completed requests as records are added. If this timeout "
-            + "is exceeded the task will fail.";
+
+    public static final String BULK_GROUP_NAME = "Bulk settings";
+
+    public static final String BULK_MAX_SIZE = "bulk.max.size";
+
+    public static final String BULK_MAX_SIZE_DOCS = "Sets when to flush a new bulk request based on the size "
+            + "in bytes of actions currently added. " + "A request is sent once that size has been exceeded. "
+            + "Defaults to 5 megabytes. Can be set to -1 to disable it.";
+
+    public static final String BULK_MAX_OPERATIONS_SIZE = "bulk.max.operations.size";
+
+    public static final String BULK_MAX_OPERATIONS_SIZE_DOCS = "Sets when to flush a new bulk request "
+            + "based on the number of operations currently added. "
+            + "Defaults to 1000. Can be set to -1 to disable it.";
+
+    public static final String BULK_MAX_CONCURRENT_REQUESTS_NUMBER = "bulk.max.concurrent.requests";
+
+    public static final String BULK_MAX_CONCURRENT_REQUESTS_NUMBER_DOCS = "Sets the number of concurrent requests allowed"
+            + " to be executed. "
+            + "A value of 1 means 1 request is allowed to be executed while accumulating new bulk requests. "
+            + "Defaults to 1.";
+
     public static final String MAX_RETRIES_CONFIG = "max.retries";
     private static final String MAX_RETRIES_DOC = "The maximum number of retries that are allowed for failed indexing requests. If the retry "
             + "attempts are exhausted the task will fail.";
@@ -222,6 +223,7 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
     protected static ConfigDef baseConfigDef() {
         final ConfigDef configDef = new ConfigDef();
         addConnectorConfigs(configDef);
+        addBulkConfig(configDef);
         addSslConfig(configDef);
         addConversionConfigs(configDef);
         addDataStreamConfig(configDef);
@@ -270,16 +272,6 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
                 return String.join(", ", "http://eshost1:9200", "http://eshost2:9200");
             }
         }, Importance.HIGH, CONNECTION_URL_DOC, CONNECTOR_GROUP_NAME, ++order, Width.LONG, "Connection URLs")
-                .define(BATCH_SIZE_CONFIG, Type.INT, 2000, Importance.MEDIUM, BATCH_SIZE_DOC, CONNECTOR_GROUP_NAME,
-                        ++order, Width.SHORT, "Batch Size")
-                .define(MAX_IN_FLIGHT_REQUESTS_CONFIG, Type.INT, 5, Importance.MEDIUM, MAX_IN_FLIGHT_REQUESTS_DOC,
-                        CONNECTOR_GROUP_NAME, ++order, Width.SHORT, "Max In-flight Requests")
-                .define(MAX_BUFFERED_RECORDS_CONFIG, Type.INT, 20000, Importance.LOW, MAX_BUFFERED_RECORDS_DOC,
-                        CONNECTOR_GROUP_NAME, ++order, Width.SHORT, "Max Buffered Records")
-                .define(LINGER_MS_CONFIG, Type.LONG, 1L, Importance.LOW, LINGER_MS_DOC, CONNECTOR_GROUP_NAME, ++order,
-                        Width.SHORT, "Linger (ms)")
-                .define(FLUSH_TIMEOUT_MS_CONFIG, Type.LONG, 10000L, Importance.LOW, FLUSH_TIMEOUT_MS_DOC,
-                        CONNECTOR_GROUP_NAME, ++order, Width.SHORT, "Flush Timeout (ms)")
                 .define(MAX_RETRIES_CONFIG, Type.INT, 5, Importance.LOW, MAX_RETRIES_DOC, CONNECTOR_GROUP_NAME, ++order,
                         Width.SHORT, "Max Retries")
                 .define(RETRY_BACKOFF_MS_CONFIG, Type.LONG, 100L, Importance.LOW, RETRY_BACKOFF_MS_DOC,
@@ -288,6 +280,18 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
                         CONNECTOR_GROUP_NAME, ++order, Width.SHORT, "Connection Timeout")
                 .define(READ_TIMEOUT_MS_CONFIG, Type.INT, 3000, Importance.LOW, READ_TIMEOUT_MS_CONFIG_DOC,
                         CONNECTOR_GROUP_NAME, ++order, Width.SHORT, "Read Timeout");
+    }
+
+    private static void addBulkConfig(final ConfigDef configDef) {
+        int order = 0;
+        configDef
+                .define(BULK_MAX_SIZE, Type.INT, 5, Importance.MEDIUM, BULK_MAX_SIZE_DOCS, BULK_GROUP_NAME, ++order,
+                        Width.SHORT, "Max Size")
+                .define(BULK_MAX_OPERATIONS_SIZE, Type.INT, 1000, Importance.MEDIUM, BULK_MAX_OPERATIONS_SIZE_DOCS,
+                        BULK_GROUP_NAME, ++order, Width.SHORT, "Max operations size")
+                .define(BULK_MAX_CONCURRENT_REQUESTS_NUMBER, Type.INT, 1, Importance.LOW,
+                        BULK_MAX_CONCURRENT_REQUESTS_NUMBER_DOCS, BULK_GROUP_NAME, ++order, Width.SHORT,
+                        "Number of concurrent requests");
     }
 
     private static void addSslConfig(final ConfigDef configDef) {
@@ -500,25 +504,16 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
     public Set<String> topicIgnoreSchema() {
         return Set.copyOf(getList(OpenSearchSinkConnectorConfig.TOPIC_SCHEMA_IGNORE_CONFIG));
     }
-
-    public long flushTimeoutMs() {
-        return getLong(OpenSearchSinkConnectorConfig.FLUSH_TIMEOUT_MS_CONFIG);
+    public Integer maxSize() {
+        return getInt(BULK_MAX_SIZE);
     }
 
-    public int maxBufferedRecords() {
-        return getInt(OpenSearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG);
+    public Integer maxOperations() {
+        return getInt(BULK_MAX_OPERATIONS_SIZE);
     }
 
-    public int batchSize() {
-        return getInt(OpenSearchSinkConnectorConfig.BATCH_SIZE_CONFIG);
-    }
-
-    public long lingerMs() {
-        return getLong(OpenSearchSinkConnectorConfig.LINGER_MS_CONFIG);
-    }
-
-    public int maxInFlightRequests() {
-        return getInt(OpenSearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG);
+    public Integer maxConcurrentRequests() {
+        return getInt(BULK_MAX_CONCURRENT_REQUESTS_NUMBER);
     }
 
     public long retryBackoffMs() {

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchTaskHandler.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchTaskHandler.java
@@ -72,10 +72,22 @@ public class OpenSearchTaskHandler {
                 .setHttpClientConfigCallback(new HttpClientConfigCallback(this.config))
                 .build();
         this.client = new OpenSearchClient(transport);
-        this.bulkIngester = BulkIngester.of(b -> b.client(client)
-                .backoffPolicy(BackoffPolicy.exponentialBackoff(config.retryBackoffMs(), config.maxRetry()))
-                .maxOperations(this.config.maxBufferedRecords())
-                .listener(new ConnectorBulkListener(config, errantRecordReporter)));
+        this.bulkIngester = BulkIngester.of(b -> {
+            final var c = b.client(client)
+                    .listener(new ConnectorBulkListener(config, errantRecordReporter))
+                    .backoffPolicy(BackoffPolicy.exponentialBackoff(config.retryBackoffMs(), config.maxRetry()));
+            if (config.maxSize() != null) {
+                c.maxSize(config.maxSize());
+            }
+            if (config.maxOperations() != null) {
+                c.maxOperations(config.maxOperations());
+            }
+            if (config.maxConcurrentRequests() != null) {
+                c.maxConcurrentRequests(config.maxConcurrentRequests());
+            }
+            return c;
+
+        });
         this.bulkOperationBuilder = new BulkOperationBuilder(config);
     }
 

--- a/src/main/java/io/aiven/kafka/connect/opensearch/request/BulkOperationBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/request/BulkOperationBuilder.java
@@ -108,7 +108,7 @@ public final class BulkOperationBuilder {
                         .document(binaryData)
                         .upsert(binaryData)
                         .docAsUpsert(true)
-                        .retryOnConflict(Math.min(config.maxInFlightRequests(), 3))));
+                        .retryOnConflict(config.maxRetry())));
             } else {
                 if (config.dataStreamEnabled()) {
                     bulkOperation = BulkOperation.of(b -> b

--- a/src/test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkTaskTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkTaskTest.java
@@ -15,12 +15,10 @@
  */
 package io.aiven.kafka.connect.opensearch;
 
-import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.BEHAVIOR_ON_VERSION_CONFLICT_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.BULK_MAX_OPERATIONS_SIZE;
+import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.BULK_MAX_SIZE;
 import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
-import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.LINGER_MS_CONFIG;
-import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
-import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.MAX_RETRIES_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,10 +41,9 @@ public class OpenSearchSinkTaskTest {
     @Test
     void failToStartWhenReportIsConfiguredAndErrantRecordReporterIsMissing(final @Mock SinkTaskContext context) {
 
-        final var props = Map.of(CONNECTION_URL_CONFIG, "http://localhost", MAX_BUFFERED_RECORDS_CONFIG, "100",
-                MAX_IN_FLIGHT_REQUESTS_CONFIG, "5", BATCH_SIZE_CONFIG, "2", LINGER_MS_CONFIG, "1000",
-                MAX_RETRIES_CONFIG, "3", READ_TIMEOUT_MS_CONFIG, "1", BEHAVIOR_ON_VERSION_CONFLICT_CONFIG,
-                BehaviorOnMalformedDoc.REPORT.toString());
+        final var props = Map.of(CONNECTION_URL_CONFIG, "http://localhost", BULK_MAX_SIZE, "100",
+                BULK_MAX_OPERATIONS_SIZE, "5", MAX_RETRIES_CONFIG, "3", READ_TIMEOUT_MS_CONFIG, "1",
+                BEHAVIOR_ON_VERSION_CONFLICT_CONFIG, BehaviorOnMalformedDoc.REPORT.toString());
         when(context.errantRecordReporter()).thenReturn(null);
         final var task = new OpenSearchSinkTask();
         task.initialize(context);
@@ -57,9 +54,7 @@ public class OpenSearchSinkTaskTest {
     @Test
     void failToStartWhenReportIsConfiguredAndErrantRecordReporterIsNotSupported(final @Mock SinkTaskContext context) {
 
-        final var props = Map.of(CONNECTION_URL_CONFIG, "http://localhost", MAX_BUFFERED_RECORDS_CONFIG, "100",
-                MAX_IN_FLIGHT_REQUESTS_CONFIG, "5", BATCH_SIZE_CONFIG, "2", LINGER_MS_CONFIG, "1000",
-                MAX_RETRIES_CONFIG, "3", READ_TIMEOUT_MS_CONFIG, "1", BEHAVIOR_ON_VERSION_CONFLICT_CONFIG,
+        final var props = Map.of(CONNECTION_URL_CONFIG, "http://localhost", BEHAVIOR_ON_VERSION_CONFLICT_CONFIG,
                 BehaviorOnMalformedDoc.REPORT.toString());
         when(context.errantRecordReporter()).thenThrow(new NoSuchMethodError());
         final var task = new OpenSearchSinkTask();

--- a/src/test/java/io/aiven/kafka/connect/opensearch/request/BulkOperationBuilderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/request/BulkOperationBuilderTest.java
@@ -148,7 +148,7 @@ public class BulkOperationBuilderTest {
         assertTrue(upsertOperation.isUpdate());
         final var update = upsertOperation.update();
         assertEquals(KEY, update.id());
-        assertEquals(3, update.retryOnConflict());
+        assertEquals(config.maxRetry(), update.retryOnConflict());
 
         final var data = ReflectionUtils.tryToReadFieldValue(update.getClass().getDeclaredField("data"), update).get();
         assertTrue((Boolean) ReflectionUtils.tryToReadFieldValue(data.getClass().getDeclaredField("docAsUpsert"), data)


### PR DESCRIPTION
Removed obsolete settings:
- batch.size
- max.in.flight.requests
- max.buffered.records
- linger.ms
- flush.timeout.ms

Added new settings for bulk operations:
- bulk.max.size
- bulk.max.operations.size
- bulk.max.concurrent.requests