### PR TITLE
Avoid ServiceLoader conflict in JacksonJsonpMapper for Kafka Connect plugins    

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,13 +201,6 @@ dependencies {
     implementation "software.amazon.awssdk:sts:$awsVersion"
     implementation "software.amazon.awssdk:apache-client:$awsVersion"
 
-    // Jackson datatype modules registered explicitly in TransportProvider's AWS
-    // path to avoid ObjectMapper#findAndRegisterModules ServiceLoader conflicts
-    // inside Kafka Connect's classloader hierarchy. Versions match the
-    // jackson-databind 2.20.1 that opensearch-java 3.8.0 pulls in transitively.
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.20.1"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.20.1"
-
     testImplementation platform("org.junit:junit-bom:${junitVersion}")
     testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,13 @@ dependencies {
     implementation "software.amazon.awssdk:sts:$awsVersion"
     implementation "software.amazon.awssdk:apache-client:$awsVersion"
 
+    // Jackson datatype modules registered explicitly in TransportProvider's AWS
+    // path to avoid ObjectMapper#findAndRegisterModules ServiceLoader conflicts
+    // inside Kafka Connect's classloader hierarchy. Versions match the
+    // jackson-databind 2.20.1 that opensearch-java 3.8.0 pulls in transitively.
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.20.1"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.20.1"
+
     testImplementation platform("org.junit:junit-bom:${junitVersion}")
     testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
 

--- a/src/main/java/io/aiven/kafka/connect/opensearch/transport/TransportProvider.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/transport/TransportProvider.java
@@ -31,6 +31,7 @@ import java.time.temporal.ChronoUnit;
 
 import org.apache.kafka.connect.errors.ConnectException;
 
+import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.aws.AwsSdk2Transport;
@@ -38,8 +39,6 @@ import org.opensearch.client.transport.aws.AwsSdk2TransportOptions;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig;
 
 import org.apache.hc.client5.http.ssl.TrustAllStrategy;
@@ -60,6 +59,10 @@ public final class TransportProvider {
     private TransportProvider() {
     }
 
+    private static JsonpMapper createJsonpMapper() {
+        return new JacksonJsonpMapper(new ObjectMapper());
+    }
+
     public static OpenSearchTransport createTransport(final OpenSearchSinkConnectorConfig config) {
         final var sslContext = sslContext(config);
         return config.awsCredentialsProvider()
@@ -71,17 +74,6 @@ public final class TransportProvider {
             final AwsCredentialsProvider credentials, final OpenSearchSinkConnectorConfig config) {
         final var region = config.getString(AWS_REGION_CONFIG);
         final var serviceSigningName = config.getString(AWS_SERVICE_SIGNING_NAME_CONFIG);
-        // Build the JSON mapper explicitly with the modules opensearch-java actually
-        // needs. The default JacksonJsonpMapper constructor calls
-        // ObjectMapper#findAndRegisterModules(), which uses ServiceLoader to scan every
-        // META-INF/services/com.fasterxml.jackson.databind.Module entry visible on the
-        // classloader hierarchy. Inside Kafka Connect that scan crosses the plugin
-        // classloader boundary and resolves SPI registrations to classes from a
-        // different Jackson version, throwing
-        // ServiceConfigurationError: Jdk8Module not a subtype.
-        final var mapper = new ObjectMapper();
-        mapper.registerModule(new Jdk8Module());
-        mapper.registerModule(new JavaTimeModule());
         return new AwsSdk2Transport(
                 ApacheHttpClient.builder()
                         .connectionTimeout(Duration.of(config.connectionTimeoutMs(), ChronoUnit.MILLIS))
@@ -95,7 +87,7 @@ public final class TransportProvider {
                 config.connectionUrls().getFirst(), serviceSigningName, Region.of(region),
                 AwsSdk2TransportOptions.builder()
                         .setCredentials(credentials)
-                        .setMapper(new JacksonJsonpMapper(mapper))
+                        .setMapper(createJsonpMapper())
                         .build());
     }
 
@@ -103,6 +95,7 @@ public final class TransportProvider {
             final OpenSearchSinkConnectorConfig config) {
         return ApacheHttpClient5TransportBuilder.builder(config.httpHosts())
                 .setHttpClientConfigCallback(new HttpClientConfigCallback(sslContext, config))
+                .setMapper(createJsonpMapper())
                 .build();
     }
 

--- a/src/main/java/io/aiven/kafka/connect/opensearch/transport/TransportProvider.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/transport/TransportProvider.java
@@ -31,11 +31,15 @@ import java.time.temporal.ChronoUnit;
 
 import org.apache.kafka.connect.errors.ConnectException;
 
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.aws.AwsSdk2Transport;
 import org.opensearch.client.transport.aws.AwsSdk2TransportOptions;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig;
 
 import org.apache.hc.client5.http.ssl.TrustAllStrategy;
@@ -67,6 +71,17 @@ public final class TransportProvider {
             final AwsCredentialsProvider credentials, final OpenSearchSinkConnectorConfig config) {
         final var region = config.getString(AWS_REGION_CONFIG);
         final var serviceSigningName = config.getString(AWS_SERVICE_SIGNING_NAME_CONFIG);
+        // Build the JSON mapper explicitly with the modules opensearch-java actually
+        // needs. The default JacksonJsonpMapper constructor calls
+        // ObjectMapper#findAndRegisterModules(), which uses ServiceLoader to scan every
+        // META-INF/services/com.fasterxml.jackson.databind.Module entry visible on the
+        // classloader hierarchy. Inside Kafka Connect that scan crosses the plugin
+        // classloader boundary and resolves SPI registrations to classes from a
+        // different Jackson version, throwing
+        // ServiceConfigurationError: Jdk8Module not a subtype.
+        final var mapper = new ObjectMapper();
+        mapper.registerModule(new Jdk8Module());
+        mapper.registerModule(new JavaTimeModule());
         return new AwsSdk2Transport(
                 ApacheHttpClient.builder()
                         .connectionTimeout(Duration.of(config.connectionTimeoutMs(), ChronoUnit.MILLIS))
@@ -78,7 +93,10 @@ public final class TransportProvider {
                                         : SSLConnectionSocketFactory.getDefaultHostnameVerifier()))
                         .build(),
                 config.connectionUrls().getFirst(), serviceSigningName, Region.of(region),
-                AwsSdk2TransportOptions.builder().setCredentials(credentials).build());
+                AwsSdk2TransportOptions.builder()
+                        .setCredentials(credentials)
+                        .setMapper(new JacksonJsonpMapper(mapper))
+                        .build());
     }
 
     private static OpenSearchTransport buildApacheHttpClientTransport(final SSLContext sslContext,


### PR DESCRIPTION
## Problem                             
                                                                                                                                                                                                                                                                                                                            
  Task startup fails on Kafka Connect base images that ship Jackson `Module`  jars on the parent classpath (e.g. `confluentinc/cp-kafka-connect`):                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                            
      ServiceConfigurationError: com.fasterxml.jackson.databind.Module: <Jdk8Module|BlackbirdModule|JakartaXmlBindAnnotationModule> not a subtype                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                            
  ## Cause                               
                                                                                                                                                                                                                                                                                                                            
  `JacksonJsonpMapper`'s no-arg constructor calls `ObjectMapper.findAndRegisterModules()`. Inside Connect, the plugin's                                                                                                                                                                                                                                                     
  `PluginClassLoader` delegates resource lookups to its parent, so the SPI scan finds Module entries in parent jars. The parent's `Module` class and  the plugin's `Module` class are distinct (different classloaders), so `ServiceLoader`'s assignability check fails.                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
[KAFKA-17111](https://issues.apache.org/jira/browse/KAFKA-17111) fixed the same symptom in Apache Kafka's `JsonSerializer`/`JsonDeserializer` by removing `findAndRegisterModules()` and replacing it with explicit module registration. This PR follows the same approach.                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  ## Fix                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  Build `JacksonJsonpMapper` from a vanilla `ObjectMapper` and pass it to both  transport builders via `setMapper(...)`.