### PR TITLE
fix: bypass JacksonJsonpMapper SPI scan to avoid classloader conflict

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/opensearch/transport/TransportProvider.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/transport/TransportProvider.java
@@ -31,11 +31,14 @@ import java.time.temporal.ChronoUnit;
 
 import org.apache.kafka.connect.errors.ConnectException;
 
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.aws.AwsSdk2Transport;
 import org.opensearch.client.transport.aws.AwsSdk2TransportOptions;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig;
 
 import org.apache.hc.client5.http.ssl.TrustAllStrategy;
@@ -54,6 +57,10 @@ public final class TransportProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(TransportProvider.class);
 
     private TransportProvider() {
+    }
+
+    private static JsonpMapper createJsonpMapper() {
+        return new JacksonJsonpMapper(new ObjectMapper());
     }
 
     public static OpenSearchTransport createTransport(final OpenSearchSinkConnectorConfig config) {
@@ -78,13 +85,17 @@ public final class TransportProvider {
                                         : SSLConnectionSocketFactory.getDefaultHostnameVerifier()))
                         .build(),
                 config.connectionUrls().getFirst(), serviceSigningName, Region.of(region),
-                AwsSdk2TransportOptions.builder().setCredentials(credentials).build());
+                AwsSdk2TransportOptions.builder()
+                        .setCredentials(credentials)
+                        .setMapper(createJsonpMapper())
+                        .build());
     }
 
     private static OpenSearchTransport buildApacheHttpClientTransport(final SSLContext sslContext,
             final OpenSearchSinkConnectorConfig config) {
         return ApacheHttpClient5TransportBuilder.builder(config.httpHosts())
                 .setHttpClientConfigCallback(new HttpClientConfigCallback(sslContext, config))
+                .setMapper(createJsonpMapper())
                 .build();
     }
 


### PR DESCRIPTION
## Problem                             
                                                                                                                                                                                                                                                                                                                            
  Task startup fails on Kafka Connect base images that ship Jackson `Module`  jars on the parent classpath (e.g. `confluentinc/cp-kafka-connect`):                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                            
      ServiceConfigurationError: com.fasterxml.jackson.databind.Module: <Jdk8Module|BlackbirdModule|JakartaXmlBindAnnotationModule> not a subtype                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                            
  ## Cause                               
                                                                                                                                                                                                                                                                                                                            
  `JacksonJsonpMapper`'s no-arg constructor calls `ObjectMapper.findAndRegisterModules()`. Inside Connect, the plugin's                                                                                                                                                                                                                                                     
  `PluginClassLoader` delegates resource lookups to its parent, so the SPI scan finds Module entries in parent jars. The parent's `Module` class and  the plugin's `Module` class are distinct (different classloaders), so `ServiceLoader`'s assignability check fails.                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
[KAFKA-17111](https://issues.apache.org/jira/browse/KAFKA-17111) fixed the same symptom in Apache Kafka's `JsonSerializer`/`JsonDeserializer` by removing `findAndRegisterModules()` and replacing it with explicit module registration. This PR follows the same approach.                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  ## Fix                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  Build `JacksonJsonpMapper` from a vanilla `ObjectMapper` and pass it to both  transport builders via `setMapper(...)`.