### PR TITLE
fix(bulk): honor behavior.on.version.conflict and behavior.on.malform…

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/opensearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/bulk/BulkProcessor.java
@@ -398,15 +398,13 @@ public class BulkProcessor {
                     for (var i = 0; i < response.items().size(); i++) {
                         final var item = response.items().get(i);
                         if (item.error() != null) {
-                            if (item.status() == HttpStatus.SC_TOO_MANY_REQUESTS) {
-                                if (responseContainsMalformedDocError(item)) {
-                                    handleMalformedDoc(item, i);
-                                } else if (responseContainsVersionConflict(item)) {
-                                    handleVersionConflict(item, i);
-                                } else {
-                                    throw new RetriableError("One of the item in the bulk response failed. Reason: "
-                                            + item.error().reason());
-                                }
+                            if (responseContainsVersionConflict(item)) {
+                                handleVersionConflict(item, i);
+                            } else if (responseContainsMalformedDocError(item)) {
+                                handleMalformedDoc(item, i);
+                            } else if (item.status() == HttpStatus.SC_TOO_MANY_REQUESTS) {
+                                throw new RetriableError("One of the item in the bulk response failed. Reason: "
+                                        + item.error().reason());
                             } else {
                                 throw new ConnectException("One of the item in the bulk response aborted. Reason: "
                                         + item.error().reason());


### PR DESCRIPTION
## Problem
behavior.on.version.conflict and behavior.on.malformed.documents are silently ignored. Tasks abort on 409 / 400 errors with One of the item in the bulk response aborted, regardless of config.

## Cause
BulkProcessor only invokes handleVersionConflict / handleMalformedDoc when the response status is HTTP 429. OpenSearch returns version conflicts as 409 and malformed docs as 400, so both handlers are unreachable.

## Fix 
Inspect the error shape first; use the HTTP status only to distinguish retry (429) from abort (anything else). 409 / 400 now flow through the configured behavior.on.* policy as documented. 429 still retries; other statuses still abort.

## Test plan
./gradlew test

Reproduced with two connectors consuming the same topic and writing to the same index (identical doc ids and external versions); task stays RUNNING and conflicts are logged at the configured level. Before one connector's task  failed.