### PR TITLE
Add support for mapping to existing resources

### DIFF
--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -409,4 +409,22 @@ Data Stream
   * Default: null
   * Importance: medium
 
+Topic to Existing Resource Mappings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``existing.resource.type``
+  Specifies the type of existing OpenSearch resource to write to
+
+  * Type: string
+  * Default: none
+  * Valid Values: [index, data_stream, index_alias, data_stream_alias, none]
+  * Importance: low
+
+``topic.to.existing.resource.mapping``
+  Specifies comma-separated topic_name:resource_name mappings (e.g. topic_1:index_1,topic_2:index_2)
+
+  * Type: list
+  * Default: null
+  * Importance: low
+
 

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/AbstractIT.java
@@ -45,7 +45,7 @@ public abstract class AbstractIT {
 
     static OpenSearchContainer<?> openSearchContainer;
 
-    OpenSearchClient opensearchClient;
+    OpenSearchClient openSearchClient;
 
     @BeforeAll
     static void beforeAll() {
@@ -66,11 +66,11 @@ public abstract class AbstractIT {
         if (openSearchContainer.isSecurityEnabled())
             props.put("connection.trust.all.certificates", "true");
         final var config = new OpenSearchSinkConnectorConfig(props);
-        opensearchClient = new OpenSearchClient(TransportProvider.createTransport(config));
+        openSearchClient = new OpenSearchClient(TransportProvider.createTransport(config));
         TestUtils.waitForCondition(() -> {
             try {
                 return Set.of(HealthStatus.Green, HealthStatus.Yellow)
-                        .contains(opensearchClient.cluster().health().status());
+                        .contains(openSearchClient.cluster().health().status());
             } catch (final Exception e) {
                 return false;
             }
@@ -86,8 +86,8 @@ public abstract class AbstractIT {
     protected void waitForRecords(final String indexName, final int expectedRecords) throws InterruptedException {
         TestUtils.waitForCondition(() -> {
             try {
-                opensearchClient.indices().refresh(r -> r.index(indexName));
-                return expectedRecords == opensearchClient.count(c -> c.index(indexName)).count();
+                openSearchClient.indices().refresh(r -> r.index(indexName));
+                return expectedRecords == openSearchClient.count(c -> c.index(indexName)).count();
             } catch (final IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorExistingDataStreamIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorExistingDataStreamIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aiven.kafka.connect.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.indices.CreateDataStreamRequest;
+import org.opensearch.client.opensearch.indices.DeleteDataStreamRequest;
+import org.opensearch.client.opensearch.indices.DeleteIndexTemplateRequest;
+import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OpenSearchSinkConnectorExistingDataStreamIT extends AbstractKafkaConnectIT {
+    static final String TOPIC_NAME = "ds-topic";
+
+    static final String CONNECTOR_NAME = "os-ds-sink-connector";
+
+    static final String DATA_STREAM_NAME = "ds-index";
+
+    public OpenSearchSinkConnectorExistingDataStreamIT() {
+        super(TOPIC_NAME, CONNECTOR_NAME);
+    }
+
+    @BeforeEach
+    public void creteDataStream() throws Exception {
+        openSearchClient.indices()
+                .putIndexTemplate(PutIndexTemplateRequest.builder()
+                        .name("ds-index-template")
+                        .priority(200)
+                        .indexPatterns(DATA_STREAM_NAME)
+                        .dataStream(ds -> ds.timestampField(t -> t.name("@timestamp")))
+                        .build());
+        openSearchClient.indices().createDataStream(CreateDataStreamRequest.builder().name(DATA_STREAM_NAME).build());
+
+    }
+
+    @AfterEach
+    public void deleteDataStream() throws Exception {
+        openSearchClient.indices().deleteDataStream(DeleteDataStreamRequest.builder().name(DATA_STREAM_NAME).build());
+        openSearchClient.indices()
+                .deleteIndexTemplate(DeleteIndexTemplateRequest.builder().name("ds-index-template").build());
+    }
+
+    @Test
+    public void testConnector() throws Exception {
+        connect.configureConnector(CONNECTOR_NAME, connectorProperties(TOPIC_NAME));
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+        writeRecords(10, TOPIC_NAME);
+
+        waitForRecords(DATA_STREAM_NAME, 10);
+
+        final var searchResults = openSearchClient.search(SearchRequest.of(b -> b.index(DATA_STREAM_NAME)), Map.class)
+                .hits();
+        for (final var hit : searchResults.hits()) {
+            final var id = (Integer) hit.source().get("doc_num");
+            assertNotNull(id);
+            assertTrue(id < 10);
+        }
+    }
+    @Override
+    Map<String, String> connectorProperties(String topicName) {
+        final var props = new HashMap<>(super.connectorProperties(topicName));
+        props.put(OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE,
+                ExistingResourceType.DATA_STREAM.name().toLowerCase());
+        props.put(OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING,
+                String.format("%s:%s", TOPIC_NAME, DATA_STREAM_NAME));
+        return Map.copyOf(props);
+    }
+
+}

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorExistingIndexAliasIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorExistingIndexAliasIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aiven.kafka.connect.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.opensearch._types.WaitForActiveShards;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
+import org.opensearch.client.opensearch.indices.PutAliasRequest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OpenSearchSinkConnectorExistingIndexAliasIT extends AbstractKafkaConnectIT {
+    static final String CONNECTOR_NAME = "existing-index-alias-connector";
+
+    static final String TOPIC_NAME = "topic-for-existing-index-alias";
+
+    static final String EXISTING_INDEX_NAME = "existing-index-with-alias";
+    static final String EXISTING_INDEX_ALIAS = "existing-index-alias";
+
+    public OpenSearchSinkConnectorExistingIndexAliasIT() {
+        super(TOPIC_NAME, CONNECTOR_NAME);
+    }
+
+    @BeforeEach
+    void createIndex() throws Exception {
+        openSearchClient.indices()
+                .create(CreateIndexRequest.builder()
+                        .index(EXISTING_INDEX_NAME)
+                        .waitForActiveShards(WaitForActiveShards.builder().count(1).build())
+                        .build());
+        openSearchClient.indices()
+                .putAlias(PutAliasRequest.builder()
+                        .alias(EXISTING_INDEX_ALIAS)
+                        .index(List.of(EXISTING_INDEX_NAME))
+                        .build());
+    }
+
+    @AfterEach
+    public void deleteIndex() throws Exception {
+        openSearchClient.indices().delete(DeleteIndexRequest.builder().index(EXISTING_INDEX_NAME).build());
+    }
+
+    @Test
+    public void testConnector() throws Exception {
+        connect.configureConnector(CONNECTOR_NAME, connectorProperties(TOPIC_NAME));
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+        writeRecords(10, TOPIC_NAME);
+
+        waitForRecords(EXISTING_INDEX_ALIAS, 10);
+
+        final var searchResults = openSearchClient
+                .search(SearchRequest.of(b -> b.index(EXISTING_INDEX_ALIAS)), Map.class)
+                .hits();
+        for (final var hit : searchResults.hits()) {
+            final var id = (Integer) hit.source().get("doc_num");
+            assertNotNull(id);
+            assertTrue(id < 10);
+        }
+    }
+    @Override
+    Map<String, String> connectorProperties(String topicName) {
+        final var props = new HashMap<>(super.connectorProperties(topicName));
+        props.put(OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.name());
+        props.put(OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING,
+                String.format("%s:%s", TOPIC_NAME, EXISTING_INDEX_ALIAS));
+        return Map.copyOf(props);
+    }
+}

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorExistingIndexIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorExistingIndexIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aiven.kafka.connect.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opensearch.client.opensearch._types.WaitForActiveShards;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OpenSearchSinkConnectorExistingIndexIT extends AbstractKafkaConnectIT {
+
+    static final String CONNECTOR_NAME = "existing-index-connector";
+
+    static final String TOPIC_NAME = "topic-for-existing-index";
+
+    static final String EXISTING_INDEX_NAME = "existing-index";
+
+    public OpenSearchSinkConnectorExistingIndexIT() {
+        super(TOPIC_NAME, CONNECTOR_NAME);
+    }
+
+    @BeforeEach
+    void createIndex() throws Exception {
+        openSearchClient.indices()
+                .create(CreateIndexRequest.builder()
+                        .index(EXISTING_INDEX_NAME)
+                        .waitForActiveShards(WaitForActiveShards.builder().count(1).build())
+                        .build());
+    }
+
+    @AfterEach
+    public void deleteIndex() throws Exception {
+        openSearchClient.indices().delete(DeleteIndexRequest.builder().index(EXISTING_INDEX_NAME).build());
+    }
+
+    @Test
+    public void testConnector() throws Exception {
+        connect.configureConnector(CONNECTOR_NAME, connectorProperties(TOPIC_NAME));
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+        writeRecords(10, TOPIC_NAME);
+
+        waitForRecords(EXISTING_INDEX_NAME, 10);
+
+        final var searchResults = openSearchClient
+                .search(SearchRequest.of(b -> b.index(EXISTING_INDEX_NAME)), Map.class)
+                .hits();
+        for (final var hit : searchResults.hits()) {
+            final var id = (Integer) hit.source().get("doc_num");
+            assertNotNull(id);
+            assertTrue(id < 10);
+            assertEquals(EXISTING_INDEX_NAME, hit.index());
+        }
+    }
+    @Override
+    Map<String, String> connectorProperties(String topicName) {
+        final var props = new HashMap<>(super.connectorProperties(topicName));
+        props.put(OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE,
+                ExistingResourceType.INDEX.name().toLowerCase());
+        props.put(OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING,
+                String.format("%s:%s", TOPIC_NAME, EXISTING_INDEX_NAME));
+        return Map.copyOf(props);
+    }
+}

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorIT.java
@@ -50,7 +50,7 @@ public class OpenSearchSinkConnectorIT extends AbstractKafkaConnectIT {
 
         waitForRecords(TOPIC_NAME, 10);
 
-        final var searchResults = opensearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME)), Map.class).hits();
+        final var searchResults = openSearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME)), Map.class).hits();
         for (final var hit : searchResults.hits()) {
             final var id = (Integer) hit.source().get("doc_num");
             assertNotNull(id);
@@ -58,7 +58,7 @@ public class OpenSearchSinkConnectorIT extends AbstractKafkaConnectIT {
             assertEquals(TOPIC_NAME, hit.index());
         }
         assertEquals(DynamicMapping.True,
-                opensearchClient.indices()
+                openSearchClient.indices()
                         .getMapping(b -> b.index(List.of(TOPIC_NAME)))
                         .get(TOPIC_NAME)
                         .mappings()

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkDataStreamConnectorIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkDataStreamConnectorIT.java
@@ -122,13 +122,13 @@ public class OpenSearchSinkDataStreamConnectorIT extends AbstractKafkaConnectIT 
         waitForRecords(TOPIC_NAME1, 10);
 
         // Search for datastreams with topic name, and it should exist
-        final var dsStats = opensearchClient.indices()
+        final var dsStats = openSearchClient.indices()
                 .dataStreamsStats(DataStreamsStatsRequest.builder().name(TOPIC_NAME1).build());
         assertEquals(1, dsStats.dataStreamCount());
         deleteTopic(TOPIC_NAME1);
 
         // Delete datastream
-        opensearchClient.indices().deleteDataStream(b -> b.name(List.of(userProvidedTemplateName)));
+        openSearchClient.indices().deleteDataStream(b -> b.name(List.of(userProvidedTemplateName)));
     }
 
     // A new template will not be created, as the one provided by user already exists
@@ -150,14 +150,14 @@ public class OpenSearchSinkDataStreamConnectorIT extends AbstractKafkaConnectIT 
         waitForRecords(TOPIC_NAME1, 10);
 
         // Search for datastreams with default index - topic name, and it should not exist
-        final var dsStats = opensearchClient.indices()
+        final var dsStats = openSearchClient.indices()
                 .dataStreamsStats(DataStreamsStatsRequest.builder().name(List.of(TOPIC_NAME1)).build());
         assertEquals(1, dsStats.dataStreamCount());
         deleteTopic(TOPIC_NAME1);
     }
 
     void assertDataStream(final String dataStreamName) throws Exception {
-        final var dsStats = opensearchClient.indices()
+        final var dsStats = openSearchClient.indices()
                 .dataStreamsStats(DataStreamsStatsRequest.builder().name(List.of(dataStreamName)).build());
 
         assertEquals(1, dsStats.dataStreamCount());
@@ -166,7 +166,7 @@ public class OpenSearchSinkDataStreamConnectorIT extends AbstractKafkaConnectIT 
     }
 
     void assertDocs(final String dataStreamIndexName, final String timestampFieldName) throws Exception {
-        final var searchResults = opensearchClient
+        final var searchResults = openSearchClient
                 .search(SearchRequest.of(b -> b.index(dataStreamIndexName)), Map.class)
                 .hits();
         for (final var hit : searchResults.hits()) {
@@ -179,7 +179,7 @@ public class OpenSearchSinkDataStreamConnectorIT extends AbstractKafkaConnectIT 
     }
 
     void createDataStreamAndTemplate(String dataStream, String dataStreamTemplate) throws IOException {
-        opensearchClient.indices()
+        openSearchClient.indices()
                 .putIndexTemplate(PutIndexTemplateRequest.builder()
                         .name(dataStreamTemplate)
                         .indexPatterns(List.of(dataStream, "index-logs-*"))

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkRoutingConnectorIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkRoutingConnectorIT.java
@@ -42,7 +42,7 @@ public class OpenSearchSinkRoutingConnectorIT extends AbstractKafkaConnectIT {
 
     @BeforeEach
     void createTemplate() throws Exception {
-        opensearchClient.indices()
+        openSearchClient.indices()
                 .putIndexTemplate(PutIndexTemplateRequest.builder()
                         .name(INDEX_TEMPLATE_NAME)
                         .indexPatterns(List.of(TOPIC_NAME))
@@ -52,7 +52,7 @@ public class OpenSearchSinkRoutingConnectorIT extends AbstractKafkaConnectIT {
 
     @AfterEach
     void deleteTemplate() throws Exception {
-        opensearchClient.indices().deleteIndexTemplate(b -> b.name(INDEX_TEMPLATE_NAME));
+        openSearchClient.indices().deleteIndexTemplate(b -> b.name(INDEX_TEMPLATE_NAME));
     }
 
     @Test
@@ -95,7 +95,7 @@ public class OpenSearchSinkRoutingConnectorIT extends AbstractKafkaConnectIT {
     }
 
     void assertRoutingRecords() throws Exception {
-        var searchResults = opensearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME).routing("0")), Map.class)
+        var searchResults = openSearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME).routing("0")), Map.class)
                 .hits();
         var counter = 0;
         for (final var hit : searchResults.hits()) {
@@ -103,7 +103,7 @@ public class OpenSearchSinkRoutingConnectorIT extends AbstractKafkaConnectIT {
             assertEquals(String.valueOf(counter++), hit.source().get("doc_num").toString());
         }
 
-        searchResults = opensearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME).routing("1")), Map.class)
+        searchResults = openSearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME).routing("1")), Map.class)
                 .hits();
         for (final var hit : searchResults.hits()) {
             assertEquals("1", hit.routing());

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkTaskIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkTaskIT.java
@@ -65,10 +65,10 @@ public class OpenSearchSinkTaskIT extends AbstractIT {
 
     @AfterEach
     void tearDown() throws Exception {
-        if (opensearchClient.indices().exists(ExistsRequest.builder().index(TOPIC_NAME).build()).value()) {
-            opensearchClient.indices().delete(DeleteIndexRequest.builder().index(TOPIC_NAME).build());
+        if (openSearchClient.indices().exists(ExistsRequest.builder().index(TOPIC_NAME).build()).value()) {
+            openSearchClient.indices().delete(DeleteIndexRequest.builder().index(TOPIC_NAME).build());
             TestUtils.waitForCondition(
-                    () -> !opensearchClient.indices().exists(ExistsRequest.builder().index(TOPIC_NAME).build()).value(),
+                    () -> !openSearchClient.indices().exists(ExistsRequest.builder().index(TOPIC_NAME).build()).value(),
                     TimeUnit.MINUTES.toMillis(1), "Index has not been deleted yet.");
         }
     }
@@ -89,7 +89,7 @@ public class OpenSearchSinkTaskIT extends AbstractIT {
         assertIndexAndMapping();
         waitForRecords(TOPIC_NAME, 1);
 
-        final var searchResults = opensearchClient.search(DEFAULT_SEARCH_REQUEST, Map.class).hits();
+        final var searchResults = openSearchClient.search(DEFAULT_SEARCH_REQUEST, Map.class).hits();
         for (final var hit : searchResults.hits()) {
             assertEquals(Base64.getEncoder().encodeToString(new byte[] { 42 }), hit.source().get("bytes"));
         }
@@ -110,7 +110,7 @@ public class OpenSearchSinkTaskIT extends AbstractIT {
         struct.put("decimal", decimal);
         runTask(getDefaultTaskProperties(false, BehaviorOnNullValues.DEFAULT),
                 List.of(new SinkRecord(TOPIC_NAME, PARTITION_1, Schema.STRING_SCHEMA, "key", structSchema, struct, 0)));
-        final var searchResults = opensearchClient.search(DEFAULT_SEARCH_REQUEST, Map.class).hits();
+        final var searchResults = openSearchClient.search(DEFAULT_SEARCH_REQUEST, Map.class).hits();
         for (final var hit : searchResults.hits()) {
             assertEquals(0.02d, hit.source().get("decimal"));
         }
@@ -132,7 +132,7 @@ public class OpenSearchSinkTaskIT extends AbstractIT {
             opensearchSinkTask.put(
                     List.of(new SinkRecord(TOPIC_NAME, PARTITION_1, Schema.STRING_SCHEMA, "key", schema, record, 0),
                             new SinkRecord(TOPIC_NAME, PARTITION_1, Schema.STRING_SCHEMA, "key", schema, record, 1)));
-            assertTrue(opensearchClient.indices().exists(ExistsRequest.builder().index(TOPIC_NAME).build()).value());
+            assertTrue(openSearchClient.indices().exists(ExistsRequest.builder().index(TOPIC_NAME).build()).value());
             opensearchSinkTask.flush(null);
             waitForRecords(TOPIC_NAME, 2);
             opensearchSinkTask.put(List.of(
@@ -314,12 +314,11 @@ public class OpenSearchSinkTaskIT extends AbstractIT {
     }
 
     void assertIndexAndMapping() throws IOException {
-        assertTrue(opensearchClient.indices().exists(ExistsRequest.builder().index(TOPIC_NAME).build()).value());
-        assertTrue(isNull(opensearchClient.indices()
+        assertTrue(openSearchClient.indices().exists(ExistsRequest.builder().index(TOPIC_NAME).build()).value());
+        assertTrue(isNull(openSearchClient.indices()
                 .getMapping(b -> b.index(List.of(TOPIC_NAME)))
                 .get(TOPIC_NAME)
                 .mappings()
                 .dynamic()));
     }
-
 }

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkUpsertConnectorIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkUpsertConnectorIT.java
@@ -58,7 +58,7 @@ public class OpenSearchSinkUpsertConnectorIT extends AbstractKafkaConnectIT {
         waitForRecords(TOPIC_NAME, 3);
 
         final var messages = new ArrayList<Pair<String, Map<?, ?>>>(3);
-        var searchResults = opensearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME)), Map.class).hits();
+        var searchResults = openSearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME)), Map.class).hits();
         for (final var hit : searchResults.hits()) {
             final var id = String.valueOf(hit.source().get("doc_num"));
             messages.add(Pair.of(id, hit.source()));
@@ -77,7 +77,7 @@ public class OpenSearchSinkUpsertConnectorIT extends AbstractKafkaConnectIT {
 
         final var foundDocs = new HashMap<Integer, Map<?, ?>>();
 
-        searchResults = opensearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME)), Map.class).hits();
+        searchResults = openSearchClient.search(SearchRequest.of(b -> b.index(TOPIC_NAME)), Map.class).hits();
         for (final var hit : searchResults.hits()) {
             final var id = Integer.valueOf(hit.id());
             foundDocs.put(id, hit.source());

--- a/src/main/java/io/aiven/kafka/connect/opensearch/ExistingResourceType.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/ExistingResourceType.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.Locale;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+public enum ExistingResourceType {
+
+    INDEX, DATA_STREAM, INDEX_ALIAS, NONE;
+
+    public static final ExistingResourceType DEFAULT = NONE;
+
+    public static final ConfigDef.Validator VALIDATOR = new ConfigDef.Validator() {
+        private final ConfigDef.ValidString validator = ConfigDef.ValidString.in(names());
+
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (value instanceof String) {
+                final String lowerStringValue = ((String) value).toLowerCase(Locale.ROOT);
+                validator.ensureValid(name, lowerStringValue);
+            } else {
+                validator.ensureValid(name, value);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return validator.toString();
+        }
+
+    };
+
+    public static String[] names() {
+        final ExistingResourceType[] behaviors = values();
+        final String[] result = new String[behaviors.length];
+
+        for (int i = 0; i < behaviors.length; i++) {
+            result[i] = behaviors[i].toString();
+        }
+
+        return result;
+    }
+
+    public static ExistingResourceType forValue(final String value) {
+        return valueOf(value.toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorConfig.java
@@ -31,6 +31,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -66,6 +68,8 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
     public static final String DATA_STREAM_GROUP_NAME = "Data Stream";
 
     public static final String DATA_CONVERSION_GROUP_NAME = "Data Conversion";
+
+    public static final String TOPIC_TO_EXISTING_RESOURCES_SETTINGS_GROUP_NAME = "Topic to Existing Resource Mappings";
 
     public static final String CONNECTION_URL_CONFIG = "connection.url";
     private static final String CONNECTION_URL_DOC = "List of OpenSearch HTTP connection URLs e.g. ``http://eshost1:9200,"
@@ -218,6 +222,14 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
     public final static String ROUTING_RECORD_VALUE_PATH = "routing.type.record.value.path";
     public final static String ROUTING_RECORD_VALUE_PATH_DOC = "Specifies the routing value which is determined by the record's value as JSON Pointer";
 
+    public final static String EXISTING_RESOURCE_TYPE = "existing.resource.type";
+
+    public final static String EXISTING_RESOURCE_TYPE_DOC = "Specifies the type of existing OpenSearch resource to write to";
+
+    public final static String TOPIC_TO_EXISTING_RESOURCE_MAPPING = "topic.to.existing.resource.mapping";
+
+    public final static String TOPIC_TO_EXISTING_RESOURCE_MAPPING_DOC = "Specifies comma-separated topic_name:resource_name mappings (e.g. topic_1:index_1,topic_2:index_2)";
+
     private JsonPointer routingRecordValueJsonPointer;
 
     static final class ConnectionUrlValidator implements ConfigDef.Validator {
@@ -242,6 +254,7 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
             return String.join(", ", "http://eshost1:9200", "endpount.com");
         }
     }
+
     protected static ConfigDef baseConfigDef() {
         final ConfigDef configDef = new ConfigDef();
         addConnectorConfigs(configDef);
@@ -249,6 +262,7 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
         addAuthenticationConfigs(configDef);
         addConversionConfigs(configDef);
         addDataStreamConfig(configDef);
+        addExistingResourcesConfigs(configDef);
         return configDef;
     }
 
@@ -314,6 +328,19 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
     public static void addAuthenticationConfigs(final ConfigDef configDef) {
         new OpenSearchBasicAuthConfigDefContributor().addConfig(configDef);
         new OpenSearchSigV4ConfigDefContributor().addConfig(configDef);
+    }
+
+    public static void addExistingResourcesConfigs(final ConfigDef configDef) {
+        int order = 0;
+        // existing.resource.type
+        configDef
+                .define(EXISTING_RESOURCE_TYPE, Type.STRING,
+                        ExistingResourceType.DEFAULT.toString().toLowerCase(Locale.ROOT),
+                        ExistingResourceType.VALIDATOR, Importance.LOW, EXISTING_RESOURCE_TYPE_DOC,
+                        TOPIC_TO_EXISTING_RESOURCES_SETTINGS_GROUP_NAME, ++order, Width.SHORT, "Existing Resource Type")
+                .define(TOPIC_TO_EXISTING_RESOURCE_MAPPING, Type.LIST, null, Importance.LOW,
+                        TOPIC_TO_EXISTING_RESOURCE_MAPPING_DOC, TOPIC_TO_EXISTING_RESOURCES_SETTINGS_GROUP_NAME,
+                        ++order, Width.LONG, "Topic to resource mappings");
     }
 
     private static void addConversionConfigs(final ConfigDef configDef) {
@@ -397,29 +424,42 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
                 || behaviorOnVersionConflict() == BehaviorOnVersionConflict.REPORT;
     }
 
-    private void validate() {
+    public void validate() {
+        if (existingResourceEnabled()) {
+            if (getBoolean(DATA_STREAM_ENABLED) && existingResourceType() == ExistingResourceType.DATA_STREAM) {
+                throw new ConfigException(
+                        "Existing datastream mappings and datastream configurations are mutually exclusive. "
+                                + "Please configure only one of these options");
+            }
+            if (getList(TOPIC_TO_EXISTING_RESOURCE_MAPPING) == null
+                    || getList(TOPIC_TO_EXISTING_RESOURCE_MAPPING).isEmpty()) {
+                throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, null);
+            }
+            validateTopicToExistingResourceMappings();
+        }
+
         if (dataStreamEnabled() && indexWriteMethod() == IndexWriteMethod.UPSERT) {
             throw new ConfigException("Data streams do not support upsert index write method");
         }
+
         if (!dataStreamEnabled() && dataStreamPrefix().isPresent()) {
             LOGGER.warn("The property data.stream.prefix was set but data streams are not enabled");
         }
         if (indexWriteMethod() == IndexWriteMethod.UPSERT && ignoreKey()
                 && documentIdStrategy() != DocumentIDStrategy.RECORD_KEY) {
             throw new ConfigException(KEY_IGNORE_ID_STRATEGY_CONFIG, documentIdStrategy().toString(),
-                    String.format("%s is not supported for index upsert. Supported is: %s",
-                            documentIdStrategy().toString(), DocumentIDStrategy.RECORD_KEY));
+                    String.format("%s is not supported for index upsert. Supported is: %s", documentIdStrategy(),
+                            DocumentIDStrategy.RECORD_KEY));
         }
         if (routingType() == RoutingType.VALUE) {
             if (routingRecordValuePath() == null) {
                 throw new ConfigException(
                         String.format("The '%s' setting must be configured when using the '%s' routing type",
-                                ROUTING_RECORD_VALUE_PATH, RoutingType.VALUE.toString()));
+                                ROUTING_RECORD_VALUE_PATH, RoutingType.VALUE));
             }
             if (routingRecordValuePath() != null && behaviorOnNullValues() == BehaviorOnNullValues.DELETE) {
                 throw new ConfigException(String.format("The '%s' can't be used together with '%s' set to '%s'",
-                        ROUTING_RECORD_VALUE_PATH, BEHAVIOR_ON_NULL_VALUES_CONFIG,
-                        BehaviorOnNullValues.DELETE.toString()));
+                        ROUTING_RECORD_VALUE_PATH, BEHAVIOR_ON_NULL_VALUES_CONFIG, BehaviorOnNullValues.DELETE));
             }
         }
         if (OpenSearchBasicAuthConfigDefContributor.configured(this)
@@ -430,6 +470,39 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
             OpenSearchSigV4ConfigDefContributor.validateSettings(this);
         } else {
             new ConnectionUrlValidator().ensureValid(CONNECTION_URL_CONFIG, connectionUrls());
+        }
+    }
+
+    private void validateTopicToExistingResourceMappings() {
+        final var topics = new HashSet<>();
+        final var mappings = getList(TOPIC_TO_EXISTING_RESOURCE_MAPPING);
+        final var resources = new HashSet<>();
+        if (mappings.size() > 10) {
+            throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, mappings.toString(),
+                    "Too many topic-to-resource mappings, the maximum allowed is 10");
+        }
+        for (final var mapping : mappings) {
+            String[] parts = mapping.split(":");
+            if (parts.length != 2) {
+                throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, mapping,
+                        "Wrong topic-to-resource mapping format, expected format is: topic_name:resource_name");
+            }
+            final var topic = parts[0].trim();
+            final var resource = parts[1].trim();
+            if (topic.isEmpty() || resource.isEmpty()) {
+                throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, mapping,
+                        "Wrong topic-to-resource mapping format, expected format is: topic_name:resource_name");
+            }
+            if (topics.contains(topic)) {
+                throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, mapping, "Topic `" + topic
+                        + "` is mapped to multiple resources. Each topic should be mapped to exactly one resource");
+            }
+            if (resources.contains(resource)) {
+                throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, mapping, "Resource `" + resource
+                        + "` is mapped from multiple topics. Each resource should be mapped to exactly one topic");
+            }
+            topics.add(topic);
+            resources.add(resource);
         }
     }
 
@@ -479,6 +552,9 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
     }
 
     public boolean dataStreamEnabled() {
+        if (existingResourceEnabled()) {
+            return existingResourceType() == ExistingResourceType.DATA_STREAM;
+        }
         return getBoolean(DATA_STREAM_ENABLED);
     }
 
@@ -563,6 +639,28 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
         return dataStreamEnabled()
                 ? this::convertTopicToDataStreamName
                 : OpenSearchSinkConnectorConfig::convertTopicToIndexName;
+    }
+
+    public boolean existingResourceEnabled() {
+        return existingResourceType() != ExistingResourceType.NONE;
+    }
+
+    public ExistingResourceType existingResourceType() {
+        return ExistingResourceType.forValue(getString(EXISTING_RESOURCE_TYPE));
+    }
+
+    public Map<String, String> topicToExistingResourceMappings() {
+        if (!existingResourceEnabled())
+            return Map.of();
+        final var mappings = new HashMap<String, String>();
+        final var topicToResourceMappings = getList(TOPIC_TO_EXISTING_RESOURCE_MAPPING);
+        for (final var mapping : topicToResourceMappings) {
+            String[] parts = mapping.split(":");
+            final var topic = parts[0].trim();
+            final var resource = parts[1].trim();
+            mappings.put(topic, resource);
+        }
+        return Map.copyOf(mappings);
     }
 
     private static String convertTopicToIndexName(final String topic) {
@@ -688,6 +786,14 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
         return routingRecordValueJsonPointer;
     }
 
+    public int maxConnPerRoute() {
+        return Math.max(10, maxInFlightRequests() * 2);
+    }
+
+    public int maxConnTotal() {
+        return maxConnPerRoute() * httpHosts().length;
+    }
+
     public static void main(final String[] args) {
         System.out.println("=========================================");
         System.out.println("OpenSearch Sink Connector Configuration Options");
@@ -696,11 +802,4 @@ public class OpenSearchSinkConnectorConfig extends AbstractConfig {
         System.out.println(CONFIG.toEnrichedRst());
     }
 
-    public int maxConnPerRoute() {
-        return Math.max(10, maxInFlightRequests() * 2);
-    }
-
-    public int maxConnTotal() {
-        return maxConnPerRoute() * httpHosts().length;
-    }
 }

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchTaskHandler.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchTaskHandler.java
@@ -56,6 +56,8 @@ public class OpenSearchTaskHandler {
 
     private final Set<String> indexCache = Collections.newSetFromMap(new BoundedHashMap());
 
+    private final Set<String> indexMappingCache = Collections.newSetFromMap(new BoundedHashMap());
+
     private final OpenSearchTransport transport;
 
     private final OpenSearchClient client;
@@ -65,6 +67,8 @@ public class OpenSearchTaskHandler {
     private final BulkOperationBuilder bulkOperationBuilder;
 
     private final BulkProcessor bulkProcessor;
+
+    private final Map<String, String> topicToExistingResourceMappings;
 
     private final static class BoundedHashMap extends LinkedHashMap<String, Boolean> {
 
@@ -91,14 +95,27 @@ public class OpenSearchTaskHandler {
         this.bulkProcessor = new BulkProcessor(Time.SYSTEM, client, config, errantRecordReporter);
         this.bulkProcessor.start();
         this.bulkOperationBuilder = new BulkOperationBuilder(config);
+        this.topicToExistingResourceMappings = config.topicToExistingResourceMappings();
     }
 
     public void put(final Collection<SinkRecord> records) {
         LOGGER.trace("Putting {} to OpenSearch", records);
         for (final var record : records) {
             try {
-                ensureIndexOrDataStreamExists(config.topicToIndexNameConverter().apply(record.topic()), record);
-                final var op = bulkOperationBuilder.buildFor(record);
+                final String indexName;
+                if (config.existingResourceEnabled()) {
+                    indexName = topicToExistingResourceMappings.get(record.topic());
+                    if (indexName == null) {
+                        throw new ConnectException("Topic `" + record.topic() + "` is not mapped to resource");
+                    }
+                    if (!indexMappingCache.contains(indexName)) {
+                        indexMapping(record).ifPresent(im -> createMappingFor(indexName, im));
+                    }
+                } else {
+                    indexName = config.topicToIndexNameConverter().apply(record.topic());
+                    ensureIndexOrDataStreamExists(config.topicToIndexNameConverter().apply(record.topic()), record);
+                }
+                final var op = bulkOperationBuilder.buildFor(indexName, record);
                 if (op != null) {
                     bulkProcessor.add(op, record, config.flushTimeoutMs());
                 }
@@ -121,6 +138,14 @@ public class OpenSearchTaskHandler {
                 createDataStreamIndex(indexName, record);
             }
             indexCache.add(indexName);
+        }
+    }
+
+    private void ensureMappingExists(final String indexName, final SinkRecord record) {
+        if (!indexMappingCache.contains(indexName)) {
+            indexMapping(record).ifPresent(m -> {
+                indexMappingCache.add(indexName);
+            });
         }
     }
 
@@ -174,16 +199,17 @@ public class OpenSearchTaskHandler {
         } catch (IOException e) {
             throw new RetriableException("Couldn't create data stream", e);
         }
-        indexMapping(record).ifPresent(im -> {
-            try {
-                client.indices().putMapping(b -> b.index(indexName).source(s -> s.withJson(im)));
-            } catch (final OpenSearchException oe) {
-                throw new ConnectException("Couldn't create mapping for " + indexName, oe);
-            } catch (final IOException e) {
-                throw new RetriableException("Couldn't create mapping for " + indexName, e);
-            }
-        });
+        indexMapping(record).ifPresent(im -> createMappingFor(indexName, im));
+    }
 
+    private void createMappingFor(final String indexName, final ByteArrayInputStream im) {
+        try {
+            client.indices().putMapping(b -> b.index(indexName).source(s -> s.withJson(im)));
+        } catch (final OpenSearchException oe) {
+            throw new ConnectException("Couldn't create mapping for " + indexName, oe);
+        } catch (final IOException e) {
+            throw new RetriableException("Couldn't create mapping for " + indexName, e);
+        }
     }
 
     private void createDataStreamIndexTemplate(final String templateName, final String indexName) {

--- a/src/main/java/io/aiven/kafka/connect/opensearch/request/BulkOperationBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/request/BulkOperationBuilder.java
@@ -53,8 +53,7 @@ public final class BulkOperationBuilder {
         this.config = config;
     }
 
-    public BulkOperation buildFor(final SinkRecord record) {
-        final var indexName = config.topicToIndexNameConverter().apply(record.topic());
+    public BulkOperation buildFor(final String indexName, final SinkRecord record) {
         if (record.value() == null) {
             switch (config.behaviorOnNullValues()) {
                 case IGNORE :

--- a/src/test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorConfigTest.java
@@ -41,6 +41,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
@@ -435,4 +437,112 @@ public class OpenSearchSinkConnectorConfigTest {
         assertEquals("some_service",
                 config.getString(OpenSearchSigV4ConfigDefContributor.AWS_SERVICE_SIGNING_NAME_CONFIG));
     }
+
+    @Test
+    void testFailsIfBothDataStreamSettingsPresents() {
+        final var e = assertThrows(ConfigException.class,
+                () -> new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                        "http://l:9200", OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                        OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE,
+                        ExistingResourceType.DATA_STREAM.name())));
+        assertEquals("Existing datastream mappings and datastream configurations are mutually exclusive."
+                + " Please configure only one of these options", e.getMessage());
+
+    }
+
+    @Test
+    void testFailsWithoutMappingSettingsPresents() {
+        final var e = assertThrows(ConfigException.class,
+                () -> new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                        "http://l:9200", OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                        OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX.name())));
+        assertEquals("Invalid value null for configuration topic.to.existing.resource.mapping", e.getMessage());
+
+    }
+
+    @Test
+    void testFailsForWrongMappingFormat() {
+        final var expectedMessageTemplate = "Invalid value %s for configuration topic.to.existing.resource.mapping: "
+                + "Wrong topic-to-resource mapping format, expected format is: topic_name:resource_name";
+
+        assertEquals(String.format(expectedMessageTemplate, "ddddd"), assertThrows(ConfigException.class,
+                () -> new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                        "http://l:9200", OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                        OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX.name(),
+                        OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, "ddddd")))
+                .getMessage());
+        assertEquals(String.format(expectedMessageTemplate, "ccccc:"), assertThrows(ConfigException.class,
+                () -> new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                        "http://l:9200", OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                        OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX.name(),
+                        OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, "ccccc:")))
+                .getMessage());
+        assertEquals(String.format(expectedMessageTemplate, ":eeeee"), assertThrows(ConfigException.class,
+                () -> new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                        "http://l:9200", OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                        OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX.name(),
+                        OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, ":eeeee")))
+                .getMessage());
+        assertEquals(String.format(expectedMessageTemplate, ":"), assertThrows(ConfigException.class,
+                () -> new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                        "http://l:9200", OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                        OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX.name(),
+                        OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, ":")))
+                .getMessage());
+        assertEquals(String.format(expectedMessageTemplate, "a;b"), assertThrows(ConfigException.class,
+                () -> new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
+                        "http://l:9200", OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                        OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX.name(),
+                        OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, "a;b")))
+                .getMessage());
+    }
+
+    @Test
+    void testFailsIfMappingToBig() {
+        final var wrongMapping = IntStream.range(0, 11)
+                .mapToObj(i -> "topic_" + i + ":index_" + i)
+                .collect(Collectors.joining(","));
+        assertEquals(
+                "Invalid value [topic_0:index_0, topic_1:index_1, topic_2:index_2, "
+                        + "topic_3:index_3, topic_4:index_4, topic_5:index_5, topic_6:index_6, topic_7:index_7, "
+                        + "topic_8:index_8, topic_9:index_9, topic_10:index_10] "
+                        + "for configuration topic.to.existing.resource.mapping: Too many topic-to-resource mappings, "
+                        + "the maximum allowed is 10",
+                assertThrows(ConfigException.class,
+                        () -> new OpenSearchSinkConnectorConfig(Map.of(
+                                OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://l:9200",
+                                OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                                OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX.name(),
+                                OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, wrongMapping)))
+                        .getMessage());
+    }
+
+    @Test
+    void testFailsForDuplicateTopicsMappings() {
+        assertEquals("Invalid value c:e for configuration topic.to.existing.resource.mapping: "
+                + "Topic `c` is mapped to multiple resources. " + "Each topic should be mapped to exactly one resource",
+                assertThrows(ConfigException.class,
+                        () -> new OpenSearchSinkConnectorConfig(Map.of(
+                                OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://l:9200",
+                                OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                                OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX.name(),
+                                OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, "a:b,c:d,c:e")))
+                        .getMessage());
+    }
+
+    @Test
+    void testFailsForDuplicateResourcesMappings() {
+        assertEquals(
+                "Invalid value e:b for configuration topic.to.existing.resource.mapping: "
+                        + "Resource `b` is mapped from multiple topics. "
+                        + "Each resource should be mapped to exactly one topic",
+                assertThrows(ConfigException.class,
+                        () -> new OpenSearchSinkConnectorConfig(Map.of(
+                                OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://l:9200",
+                                OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                                OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX.name(),
+                                OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, "a:b,c:d,e:b")))
+                        .getMessage());
+    }
+
 }

--- a/src/test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkTaskTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkTaskTest.java
@@ -23,13 +23,17 @@ import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.MA
 import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.MAX_RETRIES_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpenSearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 
 import org.junit.jupiter.api.Test;
@@ -67,4 +71,19 @@ public class OpenSearchSinkTaskTest {
         final Exception exception = assertThrows(ConnectException.class, () -> task.start(props));
         assertTrue(exception.getCause().getMessage().contains("Errant record reporter must be configured"));
     }
+
+    @Test
+    void failIfNoSuchIndexMappedToTopic(final @Mock SinkTaskContext context) {
+        final var props = Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://l:9200",
+                OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
+                OpenSearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX.name(),
+                OpenSearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, "a:b");
+        final var task = new OpenSearchSinkTask();
+        task.initialize(context);
+        task.start(props);
+        final var wringRecord = new SinkRecord("c", 1, Schema.INT32_SCHEMA, 1, Schema.INT32_SCHEMA, 2, 100L);
+        assertEquals("Topic `c` is not mapped to resource",
+                assertThrows(ConnectException.class, () -> task.put(List.of(wringRecord))).getMessage());
+    }
+
 }

--- a/src/test/java/io/aiven/kafka/connect/opensearch/request/BulkOperationBuilderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/request/BulkOperationBuilderTest.java
@@ -66,7 +66,7 @@ public class BulkOperationBuilderTest {
         final var config = new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
                 "http://localhost", OpenSearchSinkConnectorConfig.KEY_IGNORE_CONFIG, "true",
                 OpenSearchSinkConnectorConfig.KEY_IGNORE_ID_STRATEGY_CONFIG, DocumentIDStrategy.NONE.toString()));
-        assertNull(new BulkOperationBuilder(config).buildFor(createSinkRecord(null)));
+        assertNull(new BulkOperationBuilder(config).buildFor("index", createSinkRecord(null)));
     }
 
     @Test
@@ -75,7 +75,7 @@ public class BulkOperationBuilderTest {
                 "http://localhost", OpenSearchSinkConnectorConfig.KEY_IGNORE_CONFIG, "true",
                 OpenSearchSinkConnectorConfig.KEY_IGNORE_ID_STRATEGY_CONFIG, DocumentIDStrategy.NONE.toString()));
         final var bulkOperationBuilder = new BulkOperationBuilder(config);
-        final var indexBulkOperation = bulkOperationBuilder.buildFor(createSinkRecord(VALUE));
+        final var indexBulkOperation = bulkOperationBuilder.buildFor("index", createSinkRecord(VALUE));
         assertNotNull(indexBulkOperation);
         assertTrue(indexBulkOperation.isIndex());
         assertNull(indexBulkOperation.index().id(), indexBulkOperation.index().id());
@@ -94,14 +94,14 @@ public class BulkOperationBuilderTest {
 
         final var bulkOperationBuilder = new BulkOperationBuilder(config);
 
-        final var deleteOperation = bulkOperationBuilder.buildFor(createSinkRecord(null));
+        final var deleteOperation = bulkOperationBuilder.buildFor("index", createSinkRecord(null));
         assertNotNull(deleteOperation);
         assertTrue(deleteOperation.isDelete());
         assertEquals(String.format("%s+%s+%s", TOPIC, PARTITION, OFFSET), deleteOperation.delete().id(),
                 deleteOperation.delete().id());
         assertEquals(VersionType.Internal, deleteOperation.delete().versionType());
 
-        final var indexOperation = bulkOperationBuilder.buildFor(createSinkRecord(VALUE));
+        final var indexOperation = bulkOperationBuilder.buildFor("index", createSinkRecord(VALUE));
         assertNotNull(indexOperation);
         assertTrue(indexOperation.isIndex());
         assertEquals(String.format("%s+%s+%s", TOPIC, PARTITION, OFFSET), indexOperation.index().id(),
@@ -120,14 +120,14 @@ public class BulkOperationBuilderTest {
 
         final var bulkOperationBuilder = new BulkOperationBuilder(config);
 
-        final var deleteOperation = bulkOperationBuilder.buildFor(createSinkRecord(null));
+        final var deleteOperation = bulkOperationBuilder.buildFor("index", createSinkRecord(null));
         assertNotNull(deleteOperation);
         assertTrue(deleteOperation.isDelete());
         assertEquals(KEY, deleteOperation.delete().id());
         assertEquals(VersionType.External, deleteOperation.delete().versionType());
         assertEquals(OFFSET, deleteOperation.delete().version());
 
-        final var indexOperation = bulkOperationBuilder.buildFor(createSinkRecord(VALUE));
+        final var indexOperation = bulkOperationBuilder.buildFor("index", createSinkRecord(VALUE));
         assertNotNull(indexOperation);
         assertTrue(indexOperation.isIndex());
         assertEquals(KEY, indexOperation.index().id());
@@ -142,7 +142,7 @@ public class BulkOperationBuilderTest {
         final var config = new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
                 "http://localhost", OpenSearchSinkConnectorConfig.INDEX_WRITE_METHOD, IndexWriteMethod.UPSERT.name()));
 
-        final var upsertOperation = new BulkOperationBuilder(config).buildFor(createSinkRecord("aaa"));
+        final var upsertOperation = new BulkOperationBuilder(config).buildFor("index", createSinkRecord("aaa"));
 
         assertNotNull(upsertOperation);
         assertTrue(upsertOperation.isUpdate());
@@ -175,12 +175,12 @@ public class BulkOperationBuilderTest {
 
         final var bulkOperationBuilder = new BulkOperationBuilder(config);
 
-        final var deleteOperation = bulkOperationBuilder.buildFor(createSinkRecord(null));
+        final var deleteOperation = bulkOperationBuilder.buildFor("index", createSinkRecord(null));
 
         assertNotNull(deleteOperation);
         assertTrue(deleteOperation.isDelete());
 
-        final var bulkOperation = bulkOperationBuilder.buildFor(recordWithCustomTime(
+        final var bulkOperation = bulkOperationBuilder.buildFor("index", recordWithCustomTime(
                 Pair.of(OpenSearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_FIELD_DEFAULT, "12345")));
         assertNotNull(bulkOperation);
         assertTrue(bulkOperation.isCreate());
@@ -198,8 +198,8 @@ public class BulkOperationBuilderTest {
                 "http://localhost", OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
                 OpenSearchSinkConnectorConfig.DATA_STREAM_TIMESTAMP_FIELD, "t"));
 
-        final var dataStreamRequest = new BulkOperationBuilder(config)
-                .buildFor(recordWithCustomTime(Pair.of("t", "12345")));
+        final var dataStreamRequest = new BulkOperationBuilder(config).buildFor("index",
+                recordWithCustomTime(Pair.of("t", "12345")));
         assertNotNull(dataStreamRequest);
         assertTrue(dataStreamRequest.isCreate());
         final var requestPayload = objectMapper.readValue(
@@ -215,7 +215,7 @@ public class BulkOperationBuilderTest {
         final var config = new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
                 "http://localhost", OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true"));
 
-        final var dataStreamRequest = new BulkOperationBuilder(config).buildFor(createSinkRecord(VALUE));
+        final var dataStreamRequest = new BulkOperationBuilder(config).buildFor("index", createSinkRecord(VALUE));
         assertNotNull(dataStreamRequest);
         assertTrue(dataStreamRequest.isCreate());
         final var requestPayload = objectMapper.readValue(
@@ -230,7 +230,7 @@ public class BulkOperationBuilderTest {
         final var config = new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
                 "http://localhost", OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
                 OpenSearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, BehaviorOnNullValues.IGNORE.name()));
-        assertNull(new BulkOperationBuilder(config).buildFor(createSinkRecord(null)));
+        assertNull(new BulkOperationBuilder(config).buildFor("index", createSinkRecord(null)));
     }
 
     @Test
@@ -238,7 +238,8 @@ public class BulkOperationBuilderTest {
         final var config = new OpenSearchSinkConnectorConfig(Map.of(OpenSearchSinkConnectorConfig.CONNECTION_URL_CONFIG,
                 "http://localhost", OpenSearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true",
                 OpenSearchSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, BehaviorOnNullValues.FAIL.name()));
-        assertThrows(DataException.class, () -> new BulkOperationBuilder(config).buildFor(createSinkRecord(null)));
+        assertThrows(DataException.class,
+                () -> new BulkOperationBuilder(config).buildFor("index", createSinkRecord(null)));
     }
 
     SinkRecord createSinkRecord(final String value) {


### PR DESCRIPTION
Add support for mapping to existing resources.
Supported resources: `index`, `index aliases` and `data streams`

Fix for: https://github.com/Aiven-Open/opensearch-connector-for-apache-kafka/issues/417, https://github.com/Aiven-Open/opensearch-connector-for-apache-kafka/issues/414, https://github.com/Aiven-Open/opensearch-connector-for-apache-kafka/issues/358
