### PR TITLE
shorterfix(bulk): match error.type() in malformed-doc and version-conflict d…

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/opensearch/bulk/BulkProcessor.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/bulk/BulkProcessor.java
@@ -518,14 +518,19 @@ public class BulkProcessor {
 
     private boolean responseContainsVersionConflict(final BulkResponseItem bulkItemResponse) {
         return bulkItemResponse.status() == HttpStatus.SC_CONFLICT
-                || bulkItemResponse.error().reason().contains("version_conflict_engine_exception");
+                || matchesErrorType(bulkItemResponse, "version_conflict_engine_exception");
     }
 
     private boolean responseContainsMalformedDocError(final BulkResponseItem bulkItemResponse) {
-        final var reason = bulkItemResponse.error().reason();
-        return reason.contains("strict_dynamic_mapping_exception") || reason.contains("mapper_parsing_exception")
-                || reason.contains("illegal_argument_exception")
-                || reason.contains("action_request_validation_exception");
+        return matchesErrorType(bulkItemResponse, "strict_dynamic_mapping_exception")
+                || matchesErrorType(bulkItemResponse, "mapper_parsing_exception")
+                || matchesErrorType(bulkItemResponse, "illegal_argument_exception")
+                || matchesErrorType(bulkItemResponse, "action_request_validation_exception");
+    }
+
+    private static boolean matchesErrorType(final BulkResponseItem item, final String errorType) {
+        final var error = item.error();
+        return error != null && error.type() != null && error.type().contains(errorType);
     }
 
     private synchronized void onBatchCompletion(final int batchSize) {

--- a/src/test/java/io/aiven/kafka/connect/opensearch/bulk/BulkProcessorTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/bulk/BulkProcessorTest.java
@@ -496,7 +496,7 @@ public class BulkProcessorTest {
 
     private BulkResponse failedResponse(final String failureMessage, final boolean abortable) {
         final var filedResponse = BulkResponseItem
-                .of(b -> b.error(ErrorCause.builder().type("some_type").reason(failureMessage).build())
+                .of(b -> b.error(ErrorCause.builder().type(failureMessage).reason("some_reason").build())
                         .operationType(OperationType.Index)
                         .index("some_index")
                         .status(abortable ? HttpStatus.SC_BAD_REQUEST : HttpStatus.SC_TOO_MANY_REQUESTS));


### PR DESCRIPTION
## Summary

  `mapper_parsing_exception` errors (e.g. `flat_object` mismatches) **abort the sink task instead of routing to the DLQ** via `behavior.on.malformed.documents=REPORT`.

  ## Cause

  The v4.0.0 client migration replaced `getFailureMessage()` (formatted: type + reason) with separate `error().type()` and `error().reason()` fields. The substring whitelist still
  points at `reason()` only — but the class name now lives in `type()`. So `reason.contains("mapper_parsing_exception")` returns `false` for the typical OpenSearch response and the
  task aborts.

  ## Fix

  Match against `error().type()` instead.