### PR TITLE
Enhance duplicate index error detection.

### DIFF
--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorExistingAliasIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpenSearchSinkConnectorExistingAliasIT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aiven.kafka.connect.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.client.opensearch._types.WaitForActiveShards;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
+import org.opensearch.client.opensearch.indices.PutAliasRequest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OpenSearchSinkConnectorExistingAliasIT extends AbstractKafkaConnectIT {
+    static final String CONNECTOR_NAME = "existing-index-alias-connector-2";
+
+    static final String TOPIC_NAME = "existing-index-alias-2";
+
+    static final String EXISTING_INDEX_NAME = "existing-index-with-alias-2";
+    static final String EXISTING_INDEX_ALIAS = "existing-index-alias-2";
+
+    public OpenSearchSinkConnectorExistingAliasIT() {
+        super(TOPIC_NAME, CONNECTOR_NAME);
+    }
+
+    @BeforeEach
+    void createIndex() throws Exception {
+        openSearchClient.indices()
+                .create(CreateIndexRequest.builder()
+                        .index(EXISTING_INDEX_NAME)
+                        .waitForActiveShards(WaitForActiveShards.builder().count(1).build())
+                        .build());
+        openSearchClient.indices()
+                .putAlias(PutAliasRequest.builder()
+                        .alias(EXISTING_INDEX_ALIAS)
+                        .index(List.of(EXISTING_INDEX_NAME))
+                        .build());
+    }
+
+    @AfterEach
+    void deleteIndex() throws Exception {
+        openSearchClient.indices().delete(DeleteIndexRequest.builder().index(EXISTING_INDEX_NAME).build());
+    }
+
+    @Test
+    void testConnector() throws Exception {
+        connect.configureConnector(CONNECTOR_NAME, connectorProperties(TOPIC_NAME));
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+        writeRecords(10, TOPIC_NAME);
+
+        waitForRecords(EXISTING_INDEX_ALIAS, 10);
+
+        final var searchResults = openSearchClient
+                .search(SearchRequest.of(b -> b.index(EXISTING_INDEX_ALIAS)), Map.class)
+                .hits();
+        for (final var hit : searchResults.hits()) {
+            final var id = (Integer) hit.source().get("doc_num");
+            assertNotNull(id);
+            assertTrue(id < 10);
+        }
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchTaskHandler.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpenSearchTaskHandler.java
@@ -160,7 +160,7 @@ public class OpenSearchTaskHandler {
                             .waitForActiveShards(WaitForActiveShards.builder().count(1).build())
                             .build());
         } catch (final OpenSearchException oe) {
-            if ("resource_already_exists_exception".equals(oe.error().type())) {
+            if (indexAlreadyExists(oe)) {
                 LOGGER.info("Index {} already exists", indexName);
             } else {
                 throw new ConnectException("Couldn't create index " + indexName, oe);
@@ -168,6 +168,16 @@ public class OpenSearchTaskHandler {
         } catch (final IOException e) {
             throw new RetriableException("Couldn't create index " + indexName, e);
         }
+    }
+
+    private boolean indexAlreadyExists(OpenSearchException e) {
+        var error = e.error();
+        if ("resource_already_exists_exception".equals(error.type())) {
+            return true;
+        }
+
+        return "invalid_index_name_exception".equals(error.type()) && error.reason() instanceof String reason
+                && reason.contains("already exists as alias");
     }
 
     private void createDataStreamIndex(final String indexName, final SinkRecord record) {


### PR DESCRIPTION
This commit provides additional check for `OpenSearchException`. Before this commit the `error.type` was checked only for `resource_already_exists_exception`. We enhance it to also include the case when index in question is actually an alias.