### PR TITLE
Back-porting writing to index alias support from v4 to v3

### DIFF
--- a/.github/workflows/main_and_pr_workflow.yml
+++ b/.github/workflows/main_and_pr_workflow.yml
@@ -15,7 +15,7 @@ jobs:
           - { opensearch-version: 2.3.0, java-version: 11 }
           - { opensearch-version: 2.3.0, java-version: 17 }
           - { opensearch-version: 2.3.0, java-version: 19 }
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-22.04]
     name: Check on ${{ matrix.runs-on }} (JDK-${{ matrix.entry.java-version }}, OpenSearch ${{ matrix.entry.opensearch-version }})
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -27,8 +27,9 @@ jobs:
           java-version: ${{ matrix.entry.java-version }}
           distribution: 'temurin'
           cache: gradle
+      - name: Pre-pull OpenSearch image
+        run: docker pull opensearchproject/opensearch:${{ matrix.entry.opensearch-version }}
       - name: Check and Test with Gradle
-        if: ${{ matrix.runs-on == 'ubuntu-latest' }}
         run: ./gradlew check -Popensearch.testcontainers.image-version=${{ matrix.entry.opensearch-version }}
   build:
     strategy:

--- a/docs/opensearch-sink-connector-config-options.rst
+++ b/docs/opensearch-sink-connector-config-options.rst
@@ -231,4 +231,22 @@ Authentication
   * Default: null
   * Importance: medium
 
+Topic to Existing Resource Mappings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``existing.resource.type``
+  Specifies the type of existing OpenSearch resource to write to
+
+  * Type: string
+  * Default: none
+  * Valid Values: [index, data_stream, index_alias, none]
+  * Importance: low
+
+``topic.to.existing.resource.mapping``
+  Specifies comma-separated topic_name:resource_name mappings (e.g. topic_1:index_1,topic_2:index_2)
+
+  * Type: list
+  * Default: null
+  * Importance: low
+
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.aiven
-version=3.1.1
+version=3.2.0-SNAPSHOT

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorExistingIndexAliasIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorExistingIndexAliasIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.indices.CreateIndexRequest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OpensearchSinkConnectorExistingIndexAliasIT extends AbstractKafkaConnectIT {
+
+    static final String CONNECTOR_NAME = "existing-index-alias-connector";
+
+    static final String TOPIC_NAME = "topic-for-existing-index-alias";
+
+    static final String EXISTING_INDEX_NAME = "existing-index-with-alias";
+
+    static final String EXISTING_INDEX_ALIAS = "existing-index-alias";
+
+    public OpensearchSinkConnectorExistingIndexAliasIT() {
+        super(TOPIC_NAME, CONNECTOR_NAME);
+    }
+
+    @BeforeEach
+    void createIndexAndAlias() throws Exception {
+        opensearchClient.client.indices()
+                .create(new CreateIndexRequest(EXISTING_INDEX_NAME), RequestOptions.DEFAULT);
+        final var aliasRequest = new IndicesAliasesRequest();
+        aliasRequest.addAliasAction(
+                IndicesAliasesRequest.AliasActions.add()
+                        .index(EXISTING_INDEX_NAME)
+                        .alias(EXISTING_INDEX_ALIAS));
+        opensearchClient.client.indices().updateAliases(aliasRequest, RequestOptions.DEFAULT);
+    }
+
+    @AfterEach
+    void deleteIndex() throws Exception {
+        opensearchClient.client.indices()
+                .delete(new DeleteIndexRequest(EXISTING_INDEX_NAME), RequestOptions.DEFAULT);
+    }
+
+    @Test
+    public void testConnector() throws Exception {
+        connect.configureConnector(CONNECTOR_NAME, connectorProperties());
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+        writeRecords(10);
+
+        waitForRecords(EXISTING_INDEX_ALIAS, 10);
+
+        for (final var hit : search(EXISTING_INDEX_ALIAS)) {
+            final var id = (Integer) hit.getSourceAsMap().get("doc_num");
+            assertNotNull(id);
+            assertTrue(id < 10);
+            // Queries against an alias return hits from the underlying index.
+            assertEquals(EXISTING_INDEX_NAME, hit.getIndex());
+        }
+    }
+
+    @Override
+    Map<String, String> connectorProperties() {
+        final var props = new HashMap<>(super.connectorProperties());
+        props.put(OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE,
+                ExistingResourceType.INDEX_ALIAS.toString());
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING,
+                String.format("%s:%s", TOPIC_NAME, EXISTING_INDEX_ALIAS));
+        return Map.copyOf(props);
+    }
+}

--- a/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorExistingIndexIT.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorExistingIndexIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.indices.CreateIndexRequest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OpensearchSinkConnectorExistingIndexIT extends AbstractKafkaConnectIT {
+
+    static final String CONNECTOR_NAME = "existing-index-connector";
+
+    static final String TOPIC_NAME = "topic-for-existing-index";
+
+    static final String EXISTING_INDEX_NAME = "existing-index-target";
+
+    public OpensearchSinkConnectorExistingIndexIT() {
+        super(TOPIC_NAME, CONNECTOR_NAME);
+    }
+
+    @BeforeEach
+    void createIndex() throws Exception {
+        opensearchClient.client.indices()
+                .create(new CreateIndexRequest(EXISTING_INDEX_NAME), RequestOptions.DEFAULT);
+    }
+
+    @AfterEach
+    void deleteIndex() throws Exception {
+        opensearchClient.client.indices()
+                .delete(new DeleteIndexRequest(EXISTING_INDEX_NAME), RequestOptions.DEFAULT);
+    }
+
+    @Test
+    public void testConnector() throws Exception {
+        connect.configureConnector(CONNECTOR_NAME, connectorProperties());
+        waitForConnectorToStart(CONNECTOR_NAME, 1);
+
+        writeRecords(10);
+
+        waitForRecords(EXISTING_INDEX_NAME, 10);
+
+        for (final var hit : search(EXISTING_INDEX_NAME)) {
+            final var id = (Integer) hit.getSourceAsMap().get("doc_num");
+            assertNotNull(id);
+            assertTrue(id < 10);
+            assertEquals(EXISTING_INDEX_NAME, hit.getIndex());
+        }
+    }
+
+    @Override
+    Map<String, String> connectorProperties() {
+        final var props = new HashMap<>(super.connectorProperties());
+        props.put(OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE,
+                ExistingResourceType.INDEX.toString());
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING,
+                String.format("%s:%s", TOPIC_NAME, EXISTING_INDEX_NAME));
+        return Map.copyOf(props);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/opensearch/ExistingResourceType.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/ExistingResourceType.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Aiven Oy
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.opensearch;
+
+import java.util.Locale;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+public enum ExistingResourceType {
+
+    INDEX, DATA_STREAM, INDEX_ALIAS, NONE;
+
+    public static final ExistingResourceType DEFAULT = NONE;
+
+    public static final ConfigDef.Validator VALIDATOR = new ConfigDef.Validator() {
+        private final ConfigDef.ValidString validator = ConfigDef.ValidString.in(names());
+
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (value instanceof String) {
+                final String lowerStringValue = ((String) value).toLowerCase(Locale.ROOT);
+                validator.ensureValid(name, lowerStringValue);
+            } else {
+                validator.ensureValid(name, value);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return validator.toString();
+        }
+
+    };
+
+    public static String[] names() {
+        final ExistingResourceType[] behaviors = values();
+        final String[] result = new String[behaviors.length];
+
+        for (int i = 0; i < behaviors.length; i++) {
+            result[i] = behaviors[i].toString();
+        }
+
+        return result;
+    }
+
+    public static ExistingResourceType forValue(final String value) {
+        return valueOf(value.toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfig.java
@@ -19,6 +19,8 @@ package io.aiven.kafka.connect.opensearch;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -51,6 +53,8 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
     public static final String DATA_STREAM_GROUP_NAME = "Data Stream";
 
     public static final String DATA_CONVERSION_GROUP_NAME = "Data Conversion";
+
+    public static final String TOPIC_TO_EXISTING_RESOURCES_SETTINGS_GROUP_NAME = "Topic to Existing Resource Mappings";
 
     public static final String CONNECTION_URL_CONFIG = "connection.url";
     private static final String CONNECTION_URL_DOC =
@@ -204,11 +208,23 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
     public static final String DATA_STREAM_TIMESTAMP_FIELD_DOC = "The Kafka record field to use as "
             + "the timestamp for the @timestamp field in documents sent to a data stream. The default is @timestamp.";
 
+    public static final String EXISTING_RESOURCE_TYPE = "existing.resource.type";
+
+    public static final String EXISTING_RESOURCE_TYPE_DOC =
+            "Specifies the type of existing OpenSearch resource to write to";
+
+    public static final String TOPIC_TO_EXISTING_RESOURCE_MAPPING = "topic.to.existing.resource.mapping";
+
+    public static final String TOPIC_TO_EXISTING_RESOURCE_MAPPING_DOC =
+            "Specifies comma-separated topic_name:resource_name mappings "
+                    + "(e.g. topic_1:index_1,topic_2:index_2)";
+
     protected static ConfigDef baseConfigDef() {
         final ConfigDef configDef = new ConfigDef();
         addConnectorConfigs(configDef);
         addConversionConfigs(configDef);
         addDataStreamConfig(configDef);
+        addExistingResourcesConfigs(configDef);
         addSpiConfigs(configDef);
         return configDef;
     }
@@ -473,6 +489,32 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
                 "Behavior on document's version conflict (optimistic locking)");
     }
 
+    private static void addExistingResourcesConfigs(final ConfigDef configDef) {
+        int order = 0;
+        configDef.define(
+                EXISTING_RESOURCE_TYPE,
+                Type.STRING,
+                ExistingResourceType.DEFAULT.toString().toLowerCase(Locale.ROOT),
+                ExistingResourceType.VALIDATOR,
+                Importance.LOW,
+                EXISTING_RESOURCE_TYPE_DOC,
+                TOPIC_TO_EXISTING_RESOURCES_SETTINGS_GROUP_NAME,
+                ++order,
+                Width.SHORT,
+                "Existing Resource Type"
+        ).define(
+                TOPIC_TO_EXISTING_RESOURCE_MAPPING,
+                Type.LIST,
+                null,
+                Importance.LOW,
+                TOPIC_TO_EXISTING_RESOURCE_MAPPING_DOC,
+                TOPIC_TO_EXISTING_RESOURCES_SETTINGS_GROUP_NAME,
+                ++order,
+                Width.LONG,
+                "Topic to resource mappings"
+        );
+    }
+
     private static void addDataStreamConfig(final ConfigDef configDef) {
         int order = 0;
         configDef.define(
@@ -523,6 +565,7 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
     }
 
     private void validate() {
+        validateExistingResourceConfig();
         if (dataStreamEnabled() && indexWriteMethod() == IndexWriteMethod.UPSERT) {
             throw new ConfigException("Data streams do not support upsert index write method");
         }
@@ -540,6 +583,58 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
                             DocumentIDStrategy.RECORD_KEY
                     )
             );
+        }
+    }
+
+    private void validateExistingResourceConfig() {
+        if (!existingResourceEnabled()) {
+            return;
+        }
+        if (getBoolean(DATA_STREAM_ENABLED)
+                && existingResourceType() == ExistingResourceType.DATA_STREAM) {
+            throw new ConfigException(
+                    "Existing datastream mappings and datastream configurations are mutually exclusive. "
+                            + "Please configure only one of these options");
+        }
+        final List<String> mappings = getList(TOPIC_TO_EXISTING_RESOURCE_MAPPING);
+        if (mappings == null || mappings.isEmpty()) {
+            throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, null);
+        }
+        validateTopicToExistingResourceMappings();
+    }
+
+    private void validateTopicToExistingResourceMappings() {
+        final Set<String> topics = new HashSet<>();
+        final List<String> mappings = getList(TOPIC_TO_EXISTING_RESOURCE_MAPPING);
+        final Set<String> resources = new HashSet<>();
+        if (mappings.size() > 10) {
+            throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, mappings.toString(),
+                    "Too many topic-to-resource mappings, the maximum allowed is 10");
+        }
+        for (final String mapping : mappings) {
+            final String[] parts = mapping.split(":");
+            if (parts.length != 2) {
+                throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, mapping,
+                        "Wrong topic-to-resource mapping format, expected format is: topic_name:resource_name");
+            }
+            final String topic = parts[0].trim();
+            final String resource = parts[1].trim();
+            if (topic.isEmpty() || resource.isEmpty()) {
+                throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, mapping,
+                        "Wrong topic-to-resource mapping format, expected format is: topic_name:resource_name");
+            }
+            if (topics.contains(topic)) {
+                throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, mapping,
+                        "Topic `" + topic + "` is mapped to multiple resources."
+                                + " Each topic should be mapped to exactly one resource");
+            }
+            if (resources.contains(resource)) {
+                throw new ConfigException(TOPIC_TO_EXISTING_RESOURCE_MAPPING, mapping,
+                        "Resource `" + resource + "` is mapped from multiple topics."
+                                + " Each resource should be mapped to exactly one topic");
+            }
+            topics.add(topic);
+            resources.add(resource);
         }
     }
 
@@ -585,7 +680,33 @@ public class OpensearchSinkConnectorConfig extends AbstractConfig {
     }
 
     public boolean dataStreamEnabled() {
+        if (existingResourceEnabled()) {
+            return existingResourceType() == ExistingResourceType.DATA_STREAM;
+        }
         return getBoolean(DATA_STREAM_ENABLED);
+    }
+
+    public boolean existingResourceEnabled() {
+        return existingResourceType() != ExistingResourceType.NONE;
+    }
+
+    public ExistingResourceType existingResourceType() {
+        return ExistingResourceType.forValue(getString(EXISTING_RESOURCE_TYPE));
+    }
+
+    public Map<String, String> topicToExistingResourceMappings() {
+        if (!existingResourceEnabled()) {
+            return Map.of();
+        }
+        final Map<String, String> mappings = new HashMap<>();
+        final List<String> topicToResourceMappings = getList(TOPIC_TO_EXISTING_RESOURCE_MAPPING);
+        for (final String mapping : topicToResourceMappings) {
+            final String[] parts = mapping.split(":");
+            final String topic = parts[0].trim();
+            final String resource = parts[1].trim();
+            mappings.put(topic, resource);
+        }
+        return Map.copyOf(mappings);
     }
 
     public Optional<String> dataStreamPrefix() {

--- a/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTask.java
@@ -128,9 +128,21 @@ public class OpensearchSinkTask extends SinkTask {
     }
 
     private void tryWriteRecord(final SinkRecord record) {
-        final var indexOrDataStreamName = topicToIndexConverter.apply(record.topic());
-        ensureIndexOrDataStreamExists(indexOrDataStreamName);
-        checkMappingFor(indexOrDataStreamName, record);
+        final String indexOrDataStreamName;
+        if (config.existingResourceEnabled()) {
+            indexOrDataStreamName = config.topicToExistingResourceMappings().get(record.topic());
+            if (indexOrDataStreamName == null) {
+                throw new ConnectException("Topic `" + record.topic() + "` is not mapped to resource");
+            }
+            // The target index/alias/data stream is expected to exist; do not create it.
+            // Still propagate the record's mapping so schema evolution flows through, matching
+            // the non-existing-resource path.
+            checkMappingFor(indexOrDataStreamName, record);
+        } else {
+            indexOrDataStreamName = topicToIndexConverter.apply(record.topic());
+            ensureIndexOrDataStreamExists(indexOrDataStreamName);
+            checkMappingFor(indexOrDataStreamName, record);
+        }
         try {
             final var indexRecord = recordConverter.convert(record, indexOrDataStreamName);
             if (Objects.nonNull(indexRecord)) {

--- a/src/test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkConnectorConfigTest.java
@@ -33,7 +33,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class OpensearchSinkConnectorConfigTest {
@@ -254,6 +256,112 @@ public class OpensearchSinkConnectorConfigTest {
                 )
         );
         assertEquals("bbbbb", noDsPrefixConfig.topicToIndexNameConverter().apply("bbbbb"));
+    }
+
+    @Test
+    void existingResourceDisabledByDefault() {
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost");
+        final var config = new OpensearchSinkConnectorConfig(props);
+        assertFalse(config.existingResourceEnabled());
+        assertEquals(ExistingResourceType.NONE, config.existingResourceType());
+        assertTrue(config.topicToExistingResourceMappings().isEmpty());
+    }
+
+    @Test
+    void existingResourceMissingMapping() {
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost");
+        props.put(OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.toString());
+        assertThrows(ConfigException.class, () -> new OpensearchSinkConnectorConfig(props));
+    }
+
+    @Test
+    void existingResourceMalformedMapping() {
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost");
+        props.put(OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.toString());
+
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, "no_colon");
+        assertThrows(ConfigException.class, () -> new OpensearchSinkConnectorConfig(props));
+
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, ":resource");
+        assertThrows(ConfigException.class, () -> new OpensearchSinkConnectorConfig(props));
+
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, "topic:");
+        assertThrows(ConfigException.class, () -> new OpensearchSinkConnectorConfig(props));
+    }
+
+    @Test
+    void existingResourceDuplicateTopic() {
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost");
+        props.put(OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.toString());
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING,
+                "topic_1:resource_1,topic_1:resource_2");
+        assertThrows(ConfigException.class, () -> new OpensearchSinkConnectorConfig(props));
+    }
+
+    @Test
+    void existingResourceDuplicateResource() {
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost");
+        props.put(OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.toString());
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING,
+                "topic_1:resource_1,topic_2:resource_1");
+        assertThrows(ConfigException.class, () -> new OpensearchSinkConnectorConfig(props));
+    }
+
+    @Test
+    void existingResourceTooManyMappings() {
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost");
+        props.put(OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.toString());
+        final StringBuilder mappings = new StringBuilder();
+        for (int i = 0; i < 11; i++) {
+            if (i > 0) {
+                mappings.append(",");
+            }
+            mappings.append("topic_").append(i).append(":resource_").append(i);
+        }
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, mappings.toString());
+        assertThrows(ConfigException.class, () -> new OpensearchSinkConnectorConfig(props));
+    }
+
+    @Test
+    void existingResourceMutuallyExclusiveWithDataStream() {
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost");
+        props.put(OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.DATA_STREAM.toString());
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, "topic_1:ds_1");
+        props.put(OpensearchSinkConnectorConfig.DATA_STREAM_ENABLED, "true");
+        assertThrows(ConfigException.class, () -> new OpensearchSinkConnectorConfig(props));
+    }
+
+    @Test
+    void existingResourceMappingsParsed() {
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost");
+        props.put(OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.toString());
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING,
+                "topic_1:alias_1, topic_2 : alias_2");
+        final var config = new OpensearchSinkConnectorConfig(props);
+        assertTrue(config.existingResourceEnabled());
+        assertEquals(ExistingResourceType.INDEX_ALIAS, config.existingResourceType());
+        final var mappings = config.topicToExistingResourceMappings();
+        assertEquals(2, mappings.size());
+        assertEquals("alias_1", mappings.get("topic_1"));
+        assertEquals("alias_2", mappings.get("topic_2"));
+    }
+
+    @Test
+    void existingResourceDataStreamTypeMakesDataStreamEnabled() {
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost");
+        props.put(OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.DATA_STREAM.toString());
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, "topic_1:ds_1");
+        final var config = new OpensearchSinkConnectorConfig(props);
+        assertTrue(config.dataStreamEnabled());
+    }
+
+    @Test
+    void existingResourceIndexAliasTypeKeepsDataStreamDisabled() {
+        props.put(OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG, "http://localhost");
+        props.put(OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.toString());
+        props.put(OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING, "topic_1:alias_1");
+        final var config = new OpensearchSinkConnectorConfig(props);
+        assertFalse(config.dataStreamEnabled());
     }
 
 }

--- a/src/test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskTest.java
+++ b/src/test/java/io/aiven/kafka/connect/opensearch/OpensearchSinkTaskTest.java
@@ -17,10 +17,16 @@
 
 package io.aiven.kafka.connect.opensearch;
 
+import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
+
+import org.opensearch.action.DocWriteRequest;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,13 +36,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.BATCH_SIZE_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.BEHAVIOR_ON_VERSION_CONFLICT_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.CONNECTION_URL_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.EXISTING_RESOURCE_TYPE;
 import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.LINGER_MS_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.MAX_BUFFERED_RECORDS_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.MAX_IN_FLIGHT_REQUESTS_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.MAX_RETRIES_CONFIG;
 import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.READ_TIMEOUT_MS_CONFIG;
+import static io.aiven.kafka.connect.opensearch.OpensearchSinkConnectorConfig.TOPIC_TO_EXISTING_RESOURCE_MAPPING;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -80,5 +93,116 @@ public class OpensearchSinkTaskTest {
         task.initialize(context);
         final Exception exception = assertThrows(ConnectException.class, () -> task.start(props));
         assertTrue(exception.getCause().getMessage().contains("Errant record reporter must be configured"));
+    }
+
+    @Test
+    void existingResourceRoutesRecordToMappedIndexAndPushesMapping() throws Exception {
+        final var config = new OpensearchSinkConnectorConfig(Map.of(
+                CONNECTION_URL_CONFIG, "http://localhost",
+                EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.toString(),
+                TOPIC_TO_EXISTING_RESOURCE_MAPPING, "src-topic:dest-alias"
+        ));
+        final var client = mock(OpensearchClient.class);
+        when(client.hasMapping("dest-alias")).thenReturn(false);
+        final var converter = mock(RecordConverter.class);
+        final var writeRequest = mock(DocWriteRequest.class);
+        final var record = new SinkRecord("src-topic", 0, null, null, Schema.STRING_SCHEMA, "{}", 0L);
+        when(converter.convert(record, "dest-alias")).thenReturn(writeRequest);
+
+        final var task = new OpensearchSinkTask();
+        injectTaskState(task, config, client, converter);
+
+        task.put(List.of(record));
+
+        verify(client).hasMapping("dest-alias");
+        verify(client).createMapping(eq("dest-alias"), any(Schema.class));
+        verify(client).index(eq(writeRequest), eq(record));
+    }
+
+    @Test
+    void existingResourceSkipsMappingWhenSchemaIgnored() throws Exception {
+        final var config = new OpensearchSinkConnectorConfig(Map.of(
+                CONNECTION_URL_CONFIG, "http://localhost",
+                EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.toString(),
+                TOPIC_TO_EXISTING_RESOURCE_MAPPING, "src-topic:dest-alias",
+                OpensearchSinkConnectorConfig.SCHEMA_IGNORE_CONFIG, "true"
+        ));
+        final var client = mock(OpensearchClient.class);
+        final var converter = mock(RecordConverter.class);
+        final var writeRequest = mock(DocWriteRequest.class);
+        final var record = new SinkRecord("src-topic", 0, null, null, Schema.STRING_SCHEMA, "{}", 0L);
+        when(converter.convert(record, "dest-alias")).thenReturn(writeRequest);
+
+        final var task = new OpensearchSinkTask();
+        injectTaskState(task, config, client, converter);
+
+        task.put(List.of(record));
+
+        verify(client, never()).hasMapping(any());
+        verify(client, never()).createMapping(any(), any());
+        verify(client, never()).createIndex(any());
+        verify(client, never()).indexOrDataStreamExists(any());
+        verify(client).index(eq(writeRequest), eq(record));
+    }
+
+    @Test
+    void existingResourceThrowsWhenTopicNotMapped() throws Exception {
+        final var config = new OpensearchSinkConnectorConfig(Map.of(
+                CONNECTION_URL_CONFIG, "http://localhost",
+                EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.toString(),
+                TOPIC_TO_EXISTING_RESOURCE_MAPPING, "mapped-topic:dest-alias"
+        ));
+        final var client = mock(OpensearchClient.class);
+        final var converter = mock(RecordConverter.class);
+        final var record = new SinkRecord("other-topic", 0, null, null, Schema.STRING_SCHEMA, "{}", 0L);
+
+        final var task = new OpensearchSinkTask();
+        injectTaskState(task, config, client, converter);
+
+        final ConnectException ex = assertThrows(ConnectException.class, () -> task.put(List.of(record)));
+        assertTrue(ex.getMessage().contains("`other-topic` is not mapped to resource"),
+                "Unexpected exception message: " + ex.getMessage());
+        verify(client, never()).index(any(), any());
+    }
+
+    @Test
+    void existingResourceCachesMappingPerIndex() throws Exception {
+        final var config = new OpensearchSinkConnectorConfig(Map.of(
+                CONNECTION_URL_CONFIG, "http://localhost",
+                EXISTING_RESOURCE_TYPE, ExistingResourceType.INDEX_ALIAS.toString(),
+                TOPIC_TO_EXISTING_RESOURCE_MAPPING, "src-topic:dest-alias"
+        ));
+        final var client = mock(OpensearchClient.class);
+        when(client.hasMapping("dest-alias")).thenReturn(false);
+        final var converter = mock(RecordConverter.class);
+        final var writeRequest = mock(DocWriteRequest.class);
+        final var record1 = new SinkRecord("src-topic", 0, null, null, Schema.STRING_SCHEMA, "{}", 0L);
+        final var record2 = new SinkRecord("src-topic", 0, null, null, Schema.STRING_SCHEMA, "{}", 1L);
+        when(converter.convert(any(SinkRecord.class), eq("dest-alias"))).thenReturn(writeRequest);
+
+        final var task = new OpensearchSinkTask();
+        injectTaskState(task, config, client, converter);
+
+        task.put(List.of(record1, record2));
+
+        verify(client).createMapping(eq("dest-alias"), any(Schema.class));
+        verify(client).index(eq(writeRequest), eq(record1));
+        verify(client).index(eq(writeRequest), eq(record2));
+    }
+
+    private static void injectTaskState(final OpensearchSinkTask task,
+                                        final OpensearchSinkConnectorConfig config,
+                                        final OpensearchClient client,
+                                        final RecordConverter converter) throws Exception {
+        setField(task, "config", config);
+        setField(task, "client", client);
+        setField(task, "recordConverter", converter);
+        setField(task, "topicToIndexConverter", config.topicToIndexNameConverter());
+    }
+
+    private static void setField(final Object target, final String name, final Object value) throws Exception {
+        final Field field = OpensearchSinkTask.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
     }
 }


### PR DESCRIPTION
### Summary
Back-ports the "write to existing OpenSearch resources" feature (originally landed on main as PR #416 in v4.1.0) to the v3.1.x maintenance line, targeting a v3.2.0 release.

The connector can now be configured to write directly to an existing OpenSearch index, index alias, or data stream instead of creating a new index per Kafka topic. Primary use case: writing through an index alias to support rolling-index / write-alias patterns.

### Configuration
Two new properties are introduced, matching the naming, defaults, and validation rules on main:
* `existing.resource.type` (string │ none): One of `index`, `index_alias`, `data_stream`, `none`.         
*  `topic.to.existing.resource.mapping` (list   │ null ): Comma-separated `topic_name:resource_name` mappings (e.g. `topic_1:alias_1,topic_2:alias_2`). Max 10.

**Example**
```json
  connection.url=http://opensearch:9200
  existing.resource.type=index_alias
  topic.to.existing.resource.mapping=orders:orders_write_alias
  key.ignore=true
  schema.ignore=true
```